### PR TITLE
Fix pagination on audit cp screens

### DIFF
--- a/src/controllers/DefaultController.php
+++ b/src/controllers/DefaultController.php
@@ -54,7 +54,7 @@ class DefaultController extends Controller
 
         $itemsPerPage = 20;
         $currentPage  = Craft::$app->getRequest()->getParam('page', 1);
-        $urlPattern   = UrlHelper::cpUrl('audit?page=(:num)');
+        $urlPattern   = UrlHelper::cpUrl('audit') . '?page=(:num)';
         $query        = AuditRecord::find()
                                    ->orderBy('dateCreated desc')
                                    ->with('user')


### PR DESCRIPTION
Pagination is broken within the Audit admin screen, in that links all print the same (incorrect) url.

![Issue with Pagination for this plugin on craft admin screen](https://cl.ly/3c53674bae28/Image%2525202019-07-15%252520at%2525203.09.50%252520pm.png)

This is because the pattern required by `JasonGrimes\Paginator` is being fed through a Craft function that encodes any params.

As a result, the Url Pattern supplied to the Paginator doesn't contain any identifiable tokens for the paginator to replace, resulting in all pagination links pointing to `/admin/audit?page=%28%3Anum%29`, which is `page=(:num)` URI encoded via the `http_build_query()` function in `UrlHelper::_createURL()`.

After this change, the correct URLs should be printed, - `admin/audit?page=2` which works correctly.

This patch doesn't handle additional params via query string, but I can't see a scenario where it would need to within the context of pagination.

Resolves #52 