### PR TITLE
Upgrade phpuseragentparser

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
     "require": {
         "php": "^8.0.2",
         "craftcms/cms": "^4.0.0",
-        "donatj/phpuseragentparser": "^0.9.0",
+        "donatj/phpuseragentparser": "^1.7.0",
         "geoip2/geoip2": "^2.5"
     },
     "repositories": [


### PR DESCRIPTION
The 1.x branch has been the primary branch for a number of years and contains a compatibility layer so nothing should need to change.