### PR TITLE
fix: sanitize titles to prevents persistent xss vulnerabilities

### DIFF
--- a/src/services/AuditService.php
+++ b/src/services/AuditService.php
@@ -19,6 +19,7 @@ use craft\elements\GlobalSet;
 use craft\elements\User;
 use craft\events\RouteEvent;
 use craft\helpers\ElementHelper;
+use craft\helpers\Html;
 use craft\helpers\Template;
 use craft\queue\jobs\ResaveElements;
 use DateTime;
@@ -220,7 +221,7 @@ class AuditService extends Component
 
             if ($title) {
                 $model->title      = $title;
-                $snapshot['title'] = $title;
+                $snapshot['title'] = Html::encode($title);
             }
 
             $model->snapshot = $this->afterSnapshot($model, array_merge($model->snapshot, $snapshot));

--- a/src/services/AuditService.php
+++ b/src/services/AuditService.php
@@ -220,7 +220,7 @@ class AuditService extends Component
             }
 
             if ($title) {
-                $model->title      = $title;
+                $model->title      = Html::encode($title);
                 $snapshot['title'] = Html::encode($title);
             }
 


### PR DESCRIPTION
There is a persistent XSS vulnerabily within Audit that you can replicate when Creating or Amending a user within Craft. 

I have sanitized user input to fix this issue.

Are you able to merge and tag?