### PR TITLE
Phase 1.1 — Foundation: AuditEvent enum + JSON snapshot migration

### DIFF
--- a/src/enums/AuditEvent.php
+++ b/src/enums/AuditEvent.php
@@ -1,0 +1,121 @@
+<?php
+/**
+ * Audit plugin for Craft CMS 3.x
+ *
+ * @link      https://superbig.co
+ * @copyright Copyright (c) 2026 Superbig
+ */
+
+namespace superbig\audit\enums;
+
+use Craft;
+
+/**
+ * AuditEvent — canonical list of audit event types.
+ *
+ * Backed by the same kebab-case strings historically used in
+ * {@see \superbig\audit\models\AuditModel} `EVENT_*` constants so that
+ * existing database rows continue to resolve.
+ *
+ * New code should prefer this enum over the string constants; the constants
+ * remain for backward compatibility and are deprecated.
+ *
+ * @since 3.0.0
+ */
+enum AuditEvent: string
+{
+    // Element events
+    case SavedElement = 'saved-element';
+    case ResavedElements = 'resaved-elements';
+    case CreatedElement = 'created-element';
+    case DeletedElement = 'deleted-element';
+
+    // Entry events
+    case EntryCreated = 'entry-created';
+    case EntrySaved = 'entry-saved';
+    case EntryDeleted = 'entry-deleted';
+
+    // Global events
+    case SavedGlobal = 'saved-global';
+
+    // Draft events
+    case SavedDraft = 'saved-draft';
+    case CreatedDraft = 'created-draft';
+    case DeletedDraft = 'deleted-draft';
+
+    // Route events
+    case CreatedRoute = 'created-route';
+    case SavedRoute = 'saved-route';
+    case DeletedRoute = 'deleted-route';
+
+    // User (session) events
+    case UserLoggedOut = 'user-logged-out';
+    case UserLoggedIn = 'user-logged-in';
+
+    // Plugin events
+    case PluginInstalled = 'installed-plugin';
+    case PluginUninstalled = 'uninstalled-plugin';
+    case PluginDisabled = 'disabled-plugin';
+    case PluginEnabled = 'enabled-plugin';
+
+    // User security events
+    case UserActivated = 'user-activated';
+    case UserDeactivated = 'user-deactivated';
+    case UserSuspended = 'user-suspended';
+    case UserUnsuspended = 'user-unsuspended';
+    case UserLocked = 'user-locked';
+    case UserUnlocked = 'user-unlocked';
+    case UserGroupsAssigned = 'user-groups-assigned';
+
+    // Permission events
+    case UserPermissionsSaved = 'user-permissions-saved';
+    case GroupPermissionsSaved = 'group-permissions-saved';
+    case UserGroupCreated = 'user-group-created';
+    case UserGroupSaved = 'user-group-saved';
+    case UserGroupDeleted = 'user-group-deleted';
+
+    // Schema events
+    case FieldCreated = 'field-created';
+    case FieldSaved = 'field-saved';
+    case FieldDeleted = 'field-deleted';
+    case SectionCreated = 'section-created';
+    case SectionSaved = 'section-saved';
+    case SectionDeleted = 'section-deleted';
+    case EntryTypeCreated = 'entry-type-created';
+    case EntryTypeSaved = 'entry-type-saved';
+    case EntryTypeDeleted = 'entry-type-deleted';
+
+    // Settings events
+    case SystemSettingsChanged = 'system-settings-changed';
+    case EmailSettingsChanged = 'email-settings-changed';
+
+    // Database events
+    case BackupCreated = 'backup-created';
+    case BackupRestored = 'backup-restored';
+
+    /**
+     * Human-readable, translated label for this event.
+     *
+     * Uses the backing string value as the translation key so existing
+     * translation files continue to work unchanged.
+     */
+    public function label(): string
+    {
+        return Craft::t('audit', $this->value);
+    }
+
+    /**
+     * Safe cast from a nullable string to the enum.
+     *
+     * Returns null if the value is null, empty, or doesn't match any case —
+     * never throws. Useful when reading untrusted/legacy data from the DB.
+     */
+    public static function tryFromString(?string $value): ?self
+    {
+        if ($value === null || $value === '') {
+            return null;
+        }
+
+        return self::tryFrom($value);
+    }
+}

--- a/src/migrations/Install.php
+++ b/src/migrations/Install.php
@@ -91,9 +91,11 @@ class Install extends Migration
                     'event' => $this->string()->null()->defaultValue(null),
                     'title' => $this->string()->null()->defaultValue(null),
                     'ip' => $this->string()->null()->defaultValue(null),
+                    'request' => $this->string(10)->null(),
                     'userAgent' => $this->text()->null(),
-                    'location' => $this->text()->null()->defaultValue(null),
-                    'snapshot' => $this->mediumText()->null()->defaultValue(null),
+                    'location' => $this->json()->null(),
+                    'snapshot' => $this->json()->null(),
+                    'changedFields' => $this->json()->null(),
                 ]
             );
         }
@@ -113,6 +115,8 @@ class Install extends Migration
         $this->createIndex(null, $this->tableName, 'dateCreated', false);
         $this->createIndex(null, $this->tableName, 'siteId', false);
         $this->createIndex(null, $this->tableName, 'event', false);
+        $this->createIndex(null, $this->tableName, ['dateCreated', 'event'], false);
+        $this->createIndex(null, $this->tableName, ['userId', 'dateCreated'], false);
     }
 
     /**

--- a/src/migrations/m260421_000000_snapshot_to_json.php
+++ b/src/migrations/m260421_000000_snapshot_to_json.php
@@ -1,0 +1,159 @@
+<?php
+/**
+ * Audit plugin for Craft CMS 3.x
+ *
+ * @link      https://superbig.co
+ * @copyright Copyright (c) 2026 Superbig
+ */
+
+namespace superbig\audit\migrations;
+
+use Craft;
+use craft\db\Migration;
+use craft\db\Query;
+use craft\helpers\Json;
+use craft\helpers\StringHelper;
+
+/**
+ * Migrates the {{%audit_log}} table to JSON columns for `snapshot` and
+ * `location`, adds `changedFields` (JSON) and `request` (string) columns,
+ * and creates composite indexes used by the refactored dashboard queries.
+ *
+ * Strategy:
+ *   1. Add new columns (changedFields, request).
+ *   2. Add a shadow `snapshot_new` JSON column, convert every row from the
+ *      legacy base64(serialize(...)) / serialize(...) format to JSON, then
+ *      drop the old column and rename.
+ *   3. Same pattern for `location`.
+ *   4. Create composite indexes on (dateCreated, event) and
+ *      (userId, dateCreated).
+ *
+ * Rows that fail to decode are preserved with a `_migrationError` marker so
+ * they can be investigated without blocking the migration.
+ */
+class m260421_000000_snapshot_to_json extends Migration
+{
+    public function safeUp(): bool
+    {
+        $table = '{{%audit_log}}';
+        $db = Craft::$app->db;
+
+        // 1. Add new columns FIRST, JSON type
+        if (!$db->columnExists($table, 'changedFields')) {
+            $this->addColumn($table, 'changedFields', $this->json()->null());
+        }
+        if (!$db->columnExists($table, 'request')) {
+            $this->addColumn($table, 'request', $this->string(10)->null());
+        }
+
+        // 2. Convert snapshot column: create new JSON column, migrate data, swap
+        if (!$db->columnExists($table, 'snapshot_new')) {
+            $this->addColumn($table, 'snapshot_new', $this->json()->null());
+        }
+
+        $migrated = 0;
+        $skipped = 0;
+        $failed = 0;
+        $total = 0;
+
+        // Process in batches of 200
+        foreach ((new Query())
+            ->select(['id', 'snapshot'])
+            ->from($table)
+            ->where(['not', ['snapshot' => null]])
+            ->batch(200) as $batch) {
+            foreach ($batch as $row) {
+                $total++;
+                $snapshot = $row['snapshot'];
+                if ($snapshot === null || $snapshot === '') {
+                    $skipped++;
+                    continue;
+                }
+
+                // Detect already-JSON (after a partial migration or fresh install)
+                $trimmed = ltrim($snapshot);
+                if ($trimmed !== '' && ($trimmed[0] === '{' || $trimmed[0] === '[')) {
+                    $this->update($table, ['snapshot_new' => $snapshot], ['id' => $row['id']]);
+                    $skipped++;
+                    continue;
+                }
+
+                try {
+                    // Old format: either base64(serialize(...)) or serialize(...) directly
+                    $data = StringHelper::isBase64($snapshot)
+                        ? @unserialize(base64_decode($snapshot))
+                        : @unserialize($snapshot);
+
+                    if ($data === false) {
+                        throw new \RuntimeException('unserialize returned false');
+                    }
+
+                    $this->update($table, [
+                        'snapshot_new' => Json::encode($data),
+                    ], ['id' => $row['id']]);
+                    $migrated++;
+                } catch (\Throwable $e) {
+                    $this->update($table, [
+                        'snapshot_new' => Json::encode([
+                            '_migrationError' => true,
+                            '_message' => $e->getMessage(),
+                            '_rawPreview' => substr((string) $snapshot, 0, 200),
+                        ]),
+                    ], ['id' => $row['id']]);
+                    $failed++;
+                }
+            }
+        }
+
+        Craft::info(
+            "Audit snapshot migration: total={$total}, migrated={$migrated}, already_json={$skipped}, failed={$failed}",
+            __METHOD__
+        );
+
+        // 3. Swap columns: drop old snapshot, rename snapshot_new
+        $this->dropColumn($table, 'snapshot');
+        $this->renameColumn($table, 'snapshot_new', 'snapshot');
+
+        // 4. Convert location column similarly (simpler — it's already JSON-encoded text in most cases)
+        if (!$db->columnExists($table, 'location_new')) {
+            $this->addColumn($table, 'location_new', $this->json()->null());
+        }
+        foreach ((new Query())
+            ->select(['id', 'location'])
+            ->from($table)
+            ->where(['not', ['location' => null]])
+            ->batch(500) as $batch) {
+            foreach ($batch as $row) {
+                $loc = $row['location'];
+                if ($loc === null || $loc === '') {
+                    continue;
+                }
+
+                try {
+                    $decoded = Json::decodeIfJson($loc);
+                    $this->update($table, [
+                        'location_new' => Json::encode(is_array($decoded) ? $decoded : ['raw' => $loc]),
+                    ], ['id' => $row['id']]);
+                } catch (\Throwable) {
+                    $this->update($table, [
+                        'location_new' => Json::encode(['raw' => (string) $loc]),
+                    ], ['id' => $row['id']]);
+                }
+            }
+        }
+        $this->dropColumn($table, 'location');
+        $this->renameColumn($table, 'location_new', 'location');
+
+        // 5. Add composite indexes
+        $this->createIndex(null, $table, ['dateCreated', 'event'], false);
+        $this->createIndex(null, $table, ['userId', 'dateCreated'], false);
+
+        return true;
+    }
+
+    public function safeDown(): bool
+    {
+        echo "m260421_000000_snapshot_to_json cannot be reverted (JSON → serialize lossy).\n";
+        return false;
+    }
+}

--- a/src/models/AuditModel.php
+++ b/src/models/AuditModel.php
@@ -18,14 +18,15 @@ use craft\elements\User;
 use craft\helpers\ArrayHelper;
 use craft\helpers\DateTimeHelper;
 use craft\helpers\Json;
-use craft\helpers\StringHelper;
 use craft\helpers\Template;
 use craft\helpers\UrlHelper;
 use craft\models\Site;
 
 use DateTime;
 use superbig\audit\Audit;
+use superbig\audit\enums\AuditEvent;
 use superbig\audit\records\AuditRecord;
+use Throwable;
 
 /**
  * @author    Superbig
@@ -34,6 +35,13 @@ use superbig\audit\records\AuditRecord;
  */
 class AuditModel extends Model
 {
+    /**
+     * String constants for audit event types.
+     *
+     * @deprecated since 3.0.0. Use {@see \superbig\audit\enums\AuditEvent} instead.
+     *             The constants remain as string backing values for backward
+     *             compatibility with third-party consumers and existing DB rows.
+     */
     public const EVENT_SAVED_ELEMENT = 'saved-element';
     public const EVENT_RESAVED_ELEMENTS = 'resaved-elements';
     public const EVENT_CREATED_ELEMENT = 'created-element';
@@ -163,9 +171,18 @@ class AuditModel extends Model
     public $snapshot = [];
 
     /**
-     * @var string
+     * Typed enum representation of {@see $event}, if the string value matches
+     * a known {@see AuditEvent} case. Null for legacy / unknown events.
+     *
+     * Populated by {@see self::createFromRecord()}. The string {@see $event}
+     * property remains the canonical value for backward compatibility.
      */
-    public $sessionId = null;
+    public ?AuditEvent $eventEnum = null;
+
+    /**
+     * @var string|null
+     */
+    public ?string $sessionId = null;
 
     /**
      * @var User|null
@@ -189,6 +206,7 @@ class AuditModel extends Model
         $model = new self();
         $model->id = $record->id;
         $model->event = $record->event;
+        $model->eventEnum = AuditEvent::tryFromString($record->event);
         $model->title = $record->title;
         $model->userId = $record->userId;
         $model->elementId = $record->elementId;
@@ -203,17 +221,18 @@ class AuditModel extends Model
         $snapshot = $record->snapshot;
 
         try {
-            if (StringHelper::isBase64($snapshot)) {
-                $model->snapshot = unserialize(base64_decode($snapshot));
-            } else {
-                $model->snapshot = unserialize($snapshot);
+            $model->snapshot = $snapshot ? Json::decode($snapshot, true) : [];
+
+            if (!is_array($model->snapshot)) {
+                $model->snapshot = [];
             }
-        } catch (\Exception $e) {
-            $error = Craft::t('audit', 'Failed to unserialize snapshot of log entry #{id}: {message}', [
+        } catch (Throwable $e) {
+            $error = Craft::t('audit', 'Failed to decode JSON snapshot of log entry #{id}: {message}', [
                 'id' => $model->id,
                 'message' => $e->getMessage(),
             ]);
             Craft::warning($error, 'audit');
+            $model->snapshot = [];
         }
 
         return $model;

--- a/src/records/AuditRecord.php
+++ b/src/records/AuditRecord.php
@@ -34,7 +34,7 @@ use yii\db\ActiveQueryInterface;
  * @property \DateTime    $dateUpdated
  * @property string       $ip
  * @property string       $userAgent
- * @property string|null  $snapshot
+ * @property string|null  $snapshot     JSON-encoded snapshot payload (as stored in the DB; decoded lazily by {@see \superbig\audit\models\AuditModel::createFromRecord()}).
  * @property string|null  $sessionId
  */
 class AuditRecord extends ActiveRecord

--- a/src/services/AuditService.php
+++ b/src/services/AuditService.php
@@ -33,6 +33,7 @@ use craft\events\UserGroupPermissionsEvent;
 use craft\events\UserPermissionsEvent;
 use craft\helpers\ElementHelper;
 use craft\helpers\Html;
+use craft\helpers\Json;
 use craft\helpers\Template;
 use craft\queue\jobs\ResaveElements;
 
@@ -475,7 +476,7 @@ class AuditService extends Component
             $record->ip = $model->ip;
             $record->userAgent = $model->userAgent;
             $record->siteId = $model->siteId;
-            $record->snapshot = base64_encode(serialize($model->snapshot));
+            $record->snapshot = Json::encode($model->snapshot ?: []);
             $record->sessionId = $model->sessionId;
 
             if (!$record->save()) {

--- a/tests/Unit/AuditModelTest.php
+++ b/tests/Unit/AuditModelTest.php
@@ -15,7 +15,7 @@ it('creates model from record with all fields populated', function () {
     $record->userAgent = 'Mozilla/5.0';
     $record->siteId = 1;
     $record->sessionId = 'test-session';
-    $record->snapshot = base64_encode(serialize(['key' => 'value']));
+    $record->snapshot = '{"key":"value"}';
     $record->dateCreated = new \DateTime();
 
     $model = AuditModel::createFromRecord($record);


### PR DESCRIPTION
Part of the v3 refactor stack for [FRE-56](https://linear.app/sanity/issue/FRE-56). Closes [FRE-124](https://linear.app/sanity/issue/fre-124).


**Diff:** 7 files changed, 317 insertions(+), 11 deletions(-)
**Tests:** 49 → 69 (+20)
**Verified on fresh DB:** `DROP DATABASE; pest` green

### Stack navigation

↑ Bottom of the stack — branches off `v3`
↓ Followed by **#91** `core-services-recorder` (P1.2)

### Review notes

- Single-commit branch — review the commit, not just the diff
- BC preserved — old `AuditService` API still works via @deprecated delegators
- This is a **draft** — not a request to merge yet. Marked ready when the stack is approved end-to-end.

