### PR TITLE
Phase 1.2 — Core services: AuditRecorder + FieldDiffService + HandlerRegistry

### DIFF
--- a/src/Audit.php
+++ b/src/Audit.php
@@ -47,7 +47,10 @@ use craft\web\UrlManager;
 use superbig\audit\models\AuditModel;
 use superbig\audit\models\Settings;
 use superbig\audit\services\Audit_GeoService;
+use superbig\audit\services\AuditRecorder;
 use superbig\audit\services\AuditService;
+use superbig\audit\services\FieldDiffService;
+use superbig\audit\services\FieldHandlerRegistry;
 
 use superbig\audit\variables\AuditVariable;
 use yii\base\Event;
@@ -62,8 +65,11 @@ use yii\web\UserEvent;
  * @package   Audit
  * @since     1.0.0
  *
- * @property  AuditService     $auditService
- * @property  Audit_GeoService $geo
+ * @property  AuditService          $auditService
+ * @property  Audit_GeoService      $geo
+ * @property  FieldHandlerRegistry  $fieldHandlerRegistry
+ * @property  FieldDiffService      $fieldDiffService
+ * @property  AuditRecorder         $auditRecorder
  * @method  Settings getSettings()
  */
 class Audit extends Plugin
@@ -114,6 +120,9 @@ class Audit extends Plugin
         $this->setComponents([
             'auditService' => AuditService::class,
             'geo' => Audit_GeoService::class,
+            'fieldHandlerRegistry' => FieldHandlerRegistry::class,
+            'fieldDiffService' => FieldDiffService::class,
+            'auditRecorder' => AuditRecorder::class,
         ]);
 
         Event::on(

--- a/src/events/BeforeRecordEvent.php
+++ b/src/events/BeforeRecordEvent.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace superbig\audit\events;
+
+use craft\events\CancelableEvent;
+use superbig\audit\models\AuditModel;
+
+/**
+ * Event triggered before an audit log record is persisted.
+ *
+ * Handlers may:
+ *  - Mutate `$model` (e.g., add data to the snapshot, change the title)
+ *  - Set `$isValid = false` to prevent the record from being written
+ *
+ * @since 4.0.0
+ */
+class BeforeRecordEvent extends CancelableEvent
+{
+    public AuditModel $model;
+}

--- a/src/events/RegisterFieldHandlersEvent.php
+++ b/src/events/RegisterFieldHandlersEvent.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace superbig\audit\events;
+
+use yii\base\Event;
+
+/**
+ * Event for registering field handlers with the FieldHandlerRegistry.
+ *
+ * @since 4.0.0
+ */
+class RegisterFieldHandlersEvent extends Event
+{
+    /** @var string[] Array of fully-qualified handler class names */
+    public array $handlers = [];
+}

--- a/src/fieldHandlers/FieldHandler.php
+++ b/src/fieldHandlers/FieldHandler.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace superbig\audit\fieldHandlers;
+
+use craft\base\ElementInterface;
+use craft\base\FieldInterface;
+
+/**
+ * Contract for audit field handlers.
+ *
+ * A handler knows how to extract a normalized, JSON-serializable value from a Craft field,
+ * and declares a short type key used for rendering lookup.
+ *
+ * @since 4.0.0
+ */
+interface FieldHandler
+{
+    /**
+     * Which Craft field classes this handler supports.
+     *
+     * @return string[] Fully-qualified class names
+     */
+    public static function supportedFields(): array;
+
+    /**
+     * Short type key stored in the diff data for template lookup.
+     * Must be unique across handlers. Examples: 'plain', 'richtext', 'relation'.
+     */
+    public static function typeKey(): string;
+
+    /**
+     * Extract a normalized, JSON-serializable value from a field's raw value.
+     * Must return scalars, arrays, nulls — never objects or resources.
+     */
+    public function normalize(FieldInterface $field, mixed $rawValue, ElementInterface $element): mixed;
+}

--- a/src/models/AuditModel.php
+++ b/src/models/AuditModel.php
@@ -184,6 +184,12 @@ class AuditModel extends Model
      */
     public ?string $sessionId = null;
 
+    /** @var string|null Request source: 'cp', 'site', 'console', 'yaml' */
+    public ?string $request = null;
+
+    /** @var array Field-level diff data */
+    public array $changedFields = [];
+
     /**
      * @var User|null
      */
@@ -233,6 +239,18 @@ class AuditModel extends Model
             ]);
             Craft::warning($error, 'audit');
             $model->snapshot = [];
+        }
+
+        $model->request = $record->request;
+        try {
+            $model->changedFields = $record->changedFields
+                ? (Json::decode($record->changedFields, true) ?: [])
+                : [];
+            if (!is_array($model->changedFields)) {
+                $model->changedFields = [];
+            }
+        } catch (Throwable) {
+            $model->changedFields = [];
         }
 
         return $model;

--- a/src/records/AuditRecord.php
+++ b/src/records/AuditRecord.php
@@ -36,6 +36,9 @@ use yii\db\ActiveQueryInterface;
  * @property string       $userAgent
  * @property string|null  $snapshot     JSON-encoded snapshot payload (as stored in the DB; decoded lazily by {@see \superbig\audit\models\AuditModel::createFromRecord()}).
  * @property string|null  $sessionId
+ * @property string|null  $location     JSON-encoded geolocation payload.
+ * @property string|null  $changedFields JSON-encoded field diffs
+ * @property string|null  $request      Request source: 'cp', 'site', 'console', 'yaml'
  */
 class AuditRecord extends ActiveRecord
 {

--- a/src/services/AuditRecorder.php
+++ b/src/services/AuditRecorder.php
@@ -1,0 +1,152 @@
+<?php
+
+namespace superbig\audit\services;
+
+use Craft;
+use craft\base\Component;
+use craft\helpers\Json;
+use superbig\audit\Audit;
+use superbig\audit\enums\AuditEvent;
+use superbig\audit\events\BeforeRecordEvent;
+use superbig\audit\models\AuditModel;
+use superbig\audit\records\AuditRecord;
+
+/**
+ * Single entry point for recording audit events.
+ *
+ * Unlike the legacy AuditService which has ~30 event-specific methods,
+ * AuditRecorder has one `record()` method that handlers call directly.
+ *
+ * @since 4.0.0
+ */
+class AuditRecorder extends Component
+{
+    public const EVENT_BEFORE_RECORD = 'beforeRecord';
+
+    /**
+     * Record an audit event.
+     *
+     * @param AuditEvent|string $event         The event type (enum or string backing value)
+     * @param string|null       $title         Human-readable title (e.g., the entry title)
+     * @param array             $snapshot      Full state snapshot (JSON-serializable)
+     * @param array             $changedFields Diff data from FieldDiffService (optional)
+     * @param array             $overrides     Optional: override any AuditModel property
+     */
+    public function record(
+        AuditEvent|string $event,
+        ?string $title = null,
+        array $snapshot = [],
+        array $changedFields = [],
+        array $overrides = [],
+    ): ?AuditModel {
+        $settings = Audit::$plugin->getSettings();
+
+        // Build model
+        $model = new AuditModel();
+        $model->event = $event instanceof AuditEvent ? $event->value : $event;
+        $model->eventEnum = $event instanceof AuditEvent ? $event : AuditEvent::tryFromString($event);
+        $model->title = $title ?? '';
+        $model->snapshot = $snapshot;
+        $model->changedFields = $changedFields;
+
+        // Context (user/session/site/ip)
+        $this->hydrateContext($model);
+
+        // Detect YAML-apply
+        $model->request = $this->detectRequestSource();
+
+        // Apply overrides last (callers can override any property)
+        foreach ($overrides as $key => $value) {
+            if (property_exists($model, $key)) {
+                $model->$key = $value;
+            }
+        }
+
+        // Fire BeforeRecord event — allows mutation / cancellation
+        $beforeEvent = new BeforeRecordEvent(['model' => $model]);
+        $this->trigger(self::EVENT_BEFORE_RECORD, $beforeEvent);
+        if (!$beforeEvent->isValid) {
+            return null;
+        }
+
+        // Persist
+        $record = new AuditRecord();
+        $record->siteId = $model->siteId;
+        $record->sessionId = $model->sessionId;
+        $record->userId = $model->userId;
+        $record->elementId = $model->elementId;
+        $record->elementType = $model->elementType;
+        $record->parentId = $model->parentId;
+        $record->event = $model->event;
+        $record->title = $model->title;
+        $record->ip = $model->ip;
+        $record->userAgent = $model->userAgent;
+        $record->location = $model->location ? Json::encode($model->location) : null;
+        $record->snapshot = Json::encode($model->snapshot ?: []);
+        $record->changedFields = !empty($model->changedFields) ? Json::encode($model->changedFields) : null;
+        $record->request = $model->request;
+
+        if (!$record->save()) {
+            Craft::warning(
+                'Audit: failed to save record: ' . Json::encode($record->getErrors()),
+                __METHOD__
+            );
+            return null;
+        }
+
+        $model->id = $record->id;
+        $model->dateCreated = $record->dateCreated;
+
+        return $model;
+    }
+
+    /**
+     * Detect the request source.
+     * Returns 'yaml' for project-config apply, 'console' for console, 'cp'/'site' for web.
+     */
+    public function detectRequestSource(): string
+    {
+        if (Craft::$app->projectConfig->isApplyingExternalChanges) {
+            return 'yaml';
+        }
+
+        $request = Craft::$app->getRequest();
+        if ($request->isConsoleRequest) {
+            return 'console';
+        }
+        if ($request->isCpRequest ?? false) {
+            return 'cp';
+        }
+        return 'site';
+    }
+
+    /**
+     * Populate contextual fields on the model (user, session, site, ip, UA).
+     */
+    protected function hydrateContext(AuditModel $model): void
+    {
+        $model->siteId = Craft::$app->sites->currentSite->id ?? 1;
+
+        $user = Craft::$app->user->getIdentity();
+        if ($user !== null) {
+            $model->userId = $user->id;
+        }
+
+        $request = Craft::$app->getRequest();
+        if (!$request->isConsoleRequest) {
+            try {
+                $model->ip = $request->getUserIP() ?: '';
+                $model->userAgent = (string) ($request->getUserAgent() ?? '');
+            } catch (\Throwable) {
+                // Console or early-boot — leave empty
+            }
+
+            try {
+                $session = Craft::$app->getSession();
+                $model->sessionId = $session->getId() ?: null;
+            } catch (\Throwable) {
+                $model->sessionId = null;
+            }
+        }
+    }
+}

--- a/src/services/FieldDiffService.php
+++ b/src/services/FieldDiffService.php
@@ -1,0 +1,138 @@
+<?php
+
+namespace superbig\audit\services;
+
+use Craft;
+use craft\base\Component;
+use craft\base\ElementInterface;
+use craft\elements\Entry;
+use superbig\audit\Audit;
+
+/**
+ * Field diff service — captures element state and computes diffs.
+ *
+ * @since 4.0.0
+ */
+class FieldDiffService extends Component
+{
+    /** Truncation threshold per field in serialized bytes */
+    public int $maxFieldBytes = 1_000_000;
+
+    /**
+     * Capture an element's current state as a map of
+     * handle → {handler: typeKey, value: normalized}.
+     */
+    public function captureState(ElementInterface $element): array
+    {
+        $registry = Audit::$plugin->fieldHandlerRegistry;
+        $state = [];
+
+        // Native attributes
+        $state['_title'] = ['handler' => 'plain', 'value' => $element->title ?? null];
+        $state['_slug'] = ['handler' => 'plain', 'value' => $element->slug ?? null];
+        $state['_status'] = ['handler' => 'plain', 'value' => $element->getStatus()];
+        $state['_enabled'] = ['handler' => 'boolean', 'value' => (bool) $element->enabled];
+
+        if ($element instanceof Entry) {
+            $state['_postDate'] = ['handler' => 'date', 'value' => $element->postDate?->format('Y-m-d H:i:s')];
+            $state['_expiryDate'] = ['handler' => 'date', 'value' => $element->expiryDate?->format('Y-m-d H:i:s')];
+        }
+
+        // Custom fields
+        $fieldLayout = $element->getFieldLayout();
+        if ($fieldLayout !== null) {
+            foreach ($fieldLayout->getCustomFields() as $field) {
+                try {
+                    $rawValue = $element->getFieldValue($field->handle);
+                } catch (\Throwable $e) {
+                    $state[$field->handle] = [
+                        'handler' => 'error',
+                        'value' => ['_error' => true, '_message' => $e->getMessage()],
+                    ];
+                    continue;
+                }
+
+                $handler = $registry->getHandler($field);
+                $typeKey = $registry->getTypeKey($field);
+
+                try {
+                    if ($handler !== null) {
+                        $normalized = $handler->normalize($field, $rawValue, $element);
+                    } else {
+                        // Generic fallback: Craft's own serialization
+                        $normalized = $field->serializeValue($rawValue, $element);
+                    }
+
+                    // Guard against oversized values
+                    $encoded = json_encode($normalized);
+                    if ($encoded !== false && strlen($encoded) > $this->maxFieldBytes) {
+                        $normalized = [
+                            '_truncated' => true,
+                            '_originalSize' => strlen($encoded),
+                            '_preview' => is_string($normalized)
+                                ? mb_substr($normalized, 0, 1000)
+                                : null,
+                        ];
+                    }
+                } catch (\Throwable $e) {
+                    Craft::warning(
+                        "Audit: failed to normalize field {$field->handle}: {$e->getMessage()}",
+                        __METHOD__
+                    );
+                    $normalized = [
+                        '_error' => true,
+                        '_message' => $e->getMessage(),
+                    ];
+                }
+
+                $state[$field->handle] = [
+                    'handler' => $typeKey,
+                    'value' => $normalized,
+                ];
+            }
+        }
+
+        return $state;
+    }
+
+    /**
+     * Diff two states. Returns only changed entries.
+     * Shape: { handle => { handler: typeKey, from: oldValue, to: newValue } }
+     */
+    public function diff(array $oldState, array $newState): array
+    {
+        $changes = [];
+        $allKeys = array_unique(array_merge(array_keys($oldState), array_keys($newState)));
+
+        foreach ($allKeys as $key) {
+            $old = $oldState[$key] ?? null;
+            $new = $newState[$key] ?? null;
+
+            $oldValue = $old['value'] ?? null;
+            $newValue = $new['value'] ?? null;
+
+            if ($this->valuesEqual($oldValue, $newValue)) {
+                continue;
+            }
+
+            $changes[$key] = [
+                'handler' => $new['handler'] ?? $old['handler'] ?? 'generic',
+                'from' => $oldValue,
+                'to' => $newValue,
+            ];
+        }
+
+        return $changes;
+    }
+
+    private function valuesEqual(mixed $a, mixed $b): bool
+    {
+        if ($a === $b) {
+            return true;
+        }
+        if (is_array($a) && is_array($b)) {
+            return json_encode($a) === json_encode($b);
+        }
+        return false;
+    }
+}

--- a/src/services/FieldHandlerRegistry.php
+++ b/src/services/FieldHandlerRegistry.php
@@ -1,0 +1,93 @@
+<?php
+
+namespace superbig\audit\services;
+
+use craft\base\Component;
+use craft\base\FieldInterface;
+use superbig\audit\events\RegisterFieldHandlersEvent;
+use superbig\audit\fieldHandlers\FieldHandler;
+
+/**
+ * Registry of audit field handlers. Handlers are registered via the
+ * EVENT_REGISTER_HANDLERS event, and looked up by Craft field class.
+ *
+ * @since 4.0.0
+ */
+class FieldHandlerRegistry extends Component
+{
+    public const EVENT_REGISTER_HANDLERS = 'registerHandlers';
+
+    /** @var array<string, class-string<FieldHandler>> field class → handler class */
+    private array $map = [];
+
+    /** @var bool */
+    private bool $registered = false;
+
+    /**
+     * Get a handler instance for a given field, or null if none match.
+     * Parent-class checks allow handlers to match subclasses of registered fields.
+     */
+    public function getHandler(FieldInterface $field): ?FieldHandler
+    {
+        $this->ensureRegistered();
+        $fieldClass = get_class($field);
+
+        if (isset($this->map[$fieldClass])) {
+            $handlerClass = $this->map[$fieldClass];
+            return new $handlerClass();
+        }
+
+        // Walk parents (e.g., custom field extends PlainText)
+        foreach ($this->map as $targetClass => $handlerClass) {
+            if (is_a($fieldClass, $targetClass, true)) {
+                return new $handlerClass();
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * Get the type key for a field (or 'generic' if no handler registered).
+     */
+    public function getTypeKey(FieldInterface $field): string
+    {
+        $handler = $this->getHandler($field);
+        return $handler !== null ? $handler::typeKey() : 'generic';
+    }
+
+    /**
+     * Clear the registry cache (useful in tests).
+     */
+    public function reset(): void
+    {
+        $this->map = [];
+        $this->registered = false;
+    }
+
+    private function ensureRegistered(): void
+    {
+        if ($this->registered) {
+            return;
+        }
+
+        $event = new RegisterFieldHandlersEvent();
+        $this->trigger(self::EVENT_REGISTER_HANDLERS, $event);
+
+        foreach ($event->handlers as $handlerClass) {
+            if (!is_subclass_of($handlerClass, FieldHandler::class)) {
+                \Craft::warning(
+                    "Handler {$handlerClass} does not implement FieldHandler, skipping",
+                    __METHOD__
+                );
+                continue;
+            }
+
+            foreach ($handlerClass::supportedFields() as $fieldClass) {
+                $this->map[$fieldClass] = $handlerClass;
+            }
+        }
+
+        $this->registered = true;
+    }
+}

--- a/tests/Unit/AuditRecorderTest.php
+++ b/tests/Unit/AuditRecorderTest.php
@@ -1,0 +1,175 @@
+<?php
+
+use craft\elements\User;
+use superbig\audit\Audit;
+use superbig\audit\enums\AuditEvent;
+use superbig\audit\events\BeforeRecordEvent;
+use superbig\audit\records\AuditRecord;
+use superbig\audit\services\AuditRecorder;
+
+/**
+ * Helper: toggle ProjectConfig::isApplyingExternalChanges via reflection
+ * since the public setter is blocked (read-only Yii property).
+ */
+function setApplyingExternalChanges(bool $value): void
+{
+    $pc = \Craft::$app->projectConfig;
+    $ref = new \ReflectionClass($pc);
+    // Try common property names across Craft versions
+    foreach (['_applyingExternalChanges', 'applyingExternalChanges'] as $propName) {
+        if ($ref->hasProperty($propName)) {
+            $prop = $ref->getProperty($propName);
+            $prop->setAccessible(true);
+            $prop->setValue($pc, $value);
+            return;
+        }
+    }
+    // Fallback: write to the getter backing if none found (no-op if it doesn't exist)
+}
+
+beforeEach(function () {
+    AuditRecord::deleteAll();
+    // Scrub any BeforeRecord listeners from prior tests BEFORE running
+    \yii\base\Event::off(AuditRecorder::class, AuditRecorder::EVENT_BEFORE_RECORD);
+    $admin = User::find()->admin()->one();
+    if ($admin) {
+        \Craft::$app->getUser()->setIdentity($admin);
+    }
+});
+
+afterEach(function () {
+    // Reset isApplyingExternalChanges first (reflection-safe) before anything else
+    setApplyingExternalChanges(false);
+    // Targeted cleanup — only AuditRecorder event listeners
+    \yii\base\Event::off(AuditRecorder::class, AuditRecorder::EVENT_BEFORE_RECORD);
+});
+
+it('records an event with a title', function () {
+    $recorder = Audit::$plugin->auditRecorder;
+
+    $model = $recorder->record(
+        AuditEvent::UserLoggedIn,
+        'Test login',
+        ['foo' => 'bar'],
+    );
+
+    expect($model)->not->toBeNull();
+    expect($model->id)->not->toBeNull();
+    expect($model->event)->toBe(AuditEvent::UserLoggedIn->value);
+    expect($model->title)->toBe('Test login');
+    expect($model->snapshot)->toBe(['foo' => 'bar']);
+
+    $record = AuditRecord::findOne($model->id);
+    expect($record)->not->toBeNull();
+    expect($record->event)->toBe(AuditEvent::UserLoggedIn->value);
+    expect($record->title)->toBe('Test login');
+});
+
+it('accepts either an enum or a string for the event', function () {
+    $recorder = Audit::$plugin->auditRecorder;
+
+    $m1 = $recorder->record(AuditEvent::UserLoggedIn, 'a');
+    $m2 = $recorder->record('user-logged-in', 'b');
+
+    expect($m1->event)->toBe('user-logged-in');
+    expect($m1->eventEnum)->toBe(AuditEvent::UserLoggedIn);
+    expect($m2->event)->toBe('user-logged-in');
+    expect($m2->eventEnum)->toBe(AuditEvent::UserLoggedIn);
+
+    // Unknown string — eventEnum should be null but string still stored
+    $m3 = $recorder->record('wholly-unknown-event', 'c');
+    expect($m3->event)->toBe('wholly-unknown-event');
+    expect($m3->eventEnum)->toBeNull();
+});
+
+it('fires BeforeRecord event', function () {
+    $fired = false;
+    $captured = null;
+    \yii\base\Event::on(
+        AuditRecorder::class,
+        AuditRecorder::EVENT_BEFORE_RECORD,
+        function (BeforeRecordEvent $event) use (&$fired, &$captured) {
+            $fired = true;
+            $captured = $event->model->event;
+        }
+    );
+
+    Audit::$plugin->auditRecorder->record(AuditEvent::UserLoggedIn, 'Trigger');
+
+    expect($fired)->toBeTrue();
+    expect($captured)->toBe(AuditEvent::UserLoggedIn->value);
+});
+
+it('allows BeforeRecord handlers to mutate the model', function () {
+    \yii\base\Event::on(
+        AuditRecorder::class,
+        AuditRecorder::EVENT_BEFORE_RECORD,
+        function (BeforeRecordEvent $event) {
+            $event->model->title = 'Mutated';
+            $event->model->snapshot['injected'] = true;
+        }
+    );
+
+    $model = Audit::$plugin->auditRecorder->record(
+        AuditEvent::UserLoggedIn,
+        'Original',
+    );
+
+    expect($model->title)->toBe('Mutated');
+    expect($model->snapshot)->toHaveKey('injected');
+
+    $record = AuditRecord::findOne($model->id);
+    expect($record->title)->toBe('Mutated');
+});
+
+it('allows BeforeRecord handlers to veto the record', function () {
+    \yii\base\Event::on(
+        AuditRecorder::class,
+        AuditRecorder::EVENT_BEFORE_RECORD,
+        function (BeforeRecordEvent $event) {
+            $event->isValid = false;
+        }
+    );
+
+    $before = AuditRecord::find()->count();
+    $model = Audit::$plugin->auditRecorder->record(AuditEvent::UserLoggedIn, 'Veto');
+    $after = AuditRecord::find()->count();
+
+    expect($model)->toBeNull();
+    expect($after)->toBe($before);
+});
+
+it('detects YAML-apply via isApplyingExternalChanges', function () {
+    $recorder = Audit::$plugin->auditRecorder;
+
+    expect($recorder->detectRequestSource())->not->toBe('yaml');
+
+    setApplyingExternalChanges(true);
+    expect($recorder->detectRequestSource())->toBe('yaml');
+
+    setApplyingExternalChanges(false);
+    expect($recorder->detectRequestSource())->not->toBe('yaml');
+});
+
+it('persists request source and changedFields', function () {
+    $changed = [
+        '_title' => ['handler' => 'plain', 'from' => 'Old', 'to' => 'New'],
+    ];
+
+    $model = Audit::$plugin->auditRecorder->record(
+        AuditEvent::EntrySaved,
+        'An Entry',
+        ['some' => 'snap'],
+        $changed,
+    );
+
+    expect($model)->not->toBeNull();
+    expect($model->request)->not->toBeNull();
+    expect($model->changedFields)->toBe($changed);
+
+    $record = AuditRecord::findOne($model->id);
+    expect($record->request)->not->toBeNull();
+    expect($record->changedFields)->not->toBeNull();
+    $decoded = json_decode($record->changedFields, true);
+    expect($decoded)->toBe($changed);
+});

--- a/tests/Unit/FieldDiffServiceTest.php
+++ b/tests/Unit/FieldDiffServiceTest.php
@@ -1,0 +1,91 @@
+<?php
+
+use superbig\audit\services\FieldDiffService;
+
+it('returns empty diff when states are identical', function () {
+    $svc = new FieldDiffService();
+
+    $state = [
+        '_title' => ['handler' => 'plain', 'value' => 'Hello'],
+        '_slug' => ['handler' => 'plain', 'value' => 'hello'],
+    ];
+
+    expect($svc->diff($state, $state))->toBe([]);
+});
+
+it('returns changed fields', function () {
+    $svc = new FieldDiffService();
+
+    $old = [
+        '_title' => ['handler' => 'plain', 'value' => 'Old'],
+        '_slug' => ['handler' => 'plain', 'value' => 'hello'],
+    ];
+    $new = [
+        '_title' => ['handler' => 'plain', 'value' => 'New'],
+        '_slug' => ['handler' => 'plain', 'value' => 'hello'],
+    ];
+
+    $diff = $svc->diff($old, $new);
+    expect($diff)->toHaveKey('_title');
+    expect($diff)->not->toHaveKey('_slug');
+    expect($diff['_title'])->toBe([
+        'handler' => 'plain',
+        'from' => 'Old',
+        'to' => 'New',
+    ]);
+});
+
+it('detects added fields (missing on old side)', function () {
+    $svc = new FieldDiffService();
+
+    $old = [];
+    $new = ['body' => ['handler' => 'plain', 'value' => 'Added']];
+
+    $diff = $svc->diff($old, $new);
+    expect($diff)->toHaveKey('body');
+    expect($diff['body']['from'])->toBeNull();
+    expect($diff['body']['to'])->toBe('Added');
+    expect($diff['body']['handler'])->toBe('plain');
+});
+
+it('detects removed fields (missing on new side)', function () {
+    $svc = new FieldDiffService();
+
+    $old = ['body' => ['handler' => 'plain', 'value' => 'Removed']];
+    $new = [];
+
+    $diff = $svc->diff($old, $new);
+    expect($diff)->toHaveKey('body');
+    expect($diff['body']['from'])->toBe('Removed');
+    expect($diff['body']['to'])->toBeNull();
+    expect($diff['body']['handler'])->toBe('plain');
+});
+
+it('considers deeply equal arrays unchanged', function () {
+    $svc = new FieldDiffService();
+
+    $old = ['rel' => ['handler' => 'relation', 'value' => [1, 2, 3]]];
+    $new = ['rel' => ['handler' => 'relation', 'value' => [1, 2, 3]]];
+
+    expect($svc->diff($old, $new))->toBe([]);
+});
+
+it('detects differences in arrays', function () {
+    $svc = new FieldDiffService();
+
+    $old = ['rel' => ['handler' => 'relation', 'value' => [1, 2, 3]]];
+    $new = ['rel' => ['handler' => 'relation', 'value' => [1, 2, 4]]];
+
+    $diff = $svc->diff($old, $new);
+    expect($diff)->toHaveKey('rel');
+    expect($diff['rel']['from'])->toBe([1, 2, 3]);
+    expect($diff['rel']['to'])->toBe([1, 2, 4]);
+});
+
+it('exposes the maxFieldBytes threshold', function () {
+    $svc = new FieldDiffService();
+    expect($svc->maxFieldBytes)->toBe(1_000_000);
+
+    $svc->maxFieldBytes = 100;
+    expect($svc->maxFieldBytes)->toBe(100);
+});

--- a/tests/Unit/FieldHandlerRegistryTest.php
+++ b/tests/Unit/FieldHandlerRegistryTest.php
@@ -1,0 +1,148 @@
+<?php
+
+use craft\base\Field;
+use craft\fields\PlainText;
+use superbig\audit\Audit;
+use superbig\audit\events\RegisterFieldHandlersEvent;
+use superbig\audit\fieldHandlers\FieldHandler;
+use superbig\audit\services\FieldHandlerRegistry;
+
+// Dummy handler for PlainText
+class PlainHandlerStub implements FieldHandler
+{
+    public static int $loadCount = 0;
+
+    public static function supportedFields(): array
+    {
+        self::$loadCount++;
+        return [PlainText::class];
+    }
+
+    public static function typeKey(): string
+    {
+        return 'plain';
+    }
+
+    public function normalize(\craft\base\FieldInterface $field, mixed $rawValue, \craft\base\ElementInterface $element): mixed
+    {
+        return (string) $rawValue;
+    }
+}
+
+// Handler that claims NOT to implement FieldHandler (validates interface check)
+class BogusHandlerStub
+{
+    public static function supportedFields(): array { return [PlainText::class]; }
+    public static function typeKey(): string { return 'bogus'; }
+}
+
+beforeEach(function () {
+    Audit::$plugin->fieldHandlerRegistry->reset();
+    \yii\base\Event::off(FieldHandlerRegistry::class, FieldHandlerRegistry::EVENT_REGISTER_HANDLERS);
+});
+
+afterEach(function () {
+    Audit::$plugin->fieldHandlerRegistry->reset();
+    \yii\base\Event::off(FieldHandlerRegistry::class, FieldHandlerRegistry::EVENT_REGISTER_HANDLERS);
+});
+
+it('registers handlers via the event', function () {
+    \yii\base\Event::on(
+        FieldHandlerRegistry::class,
+        FieldHandlerRegistry::EVENT_REGISTER_HANDLERS,
+        function (RegisterFieldHandlersEvent $event) {
+            $event->handlers[] = PlainHandlerStub::class;
+        }
+    );
+
+    $registry = new FieldHandlerRegistry();
+    $field = new PlainText();
+
+    $handler = $registry->getHandler($field);
+    expect($handler)->toBeInstanceOf(PlainHandlerStub::class);
+    expect($registry->getTypeKey($field))->toBe('plain');
+});
+
+it('returns null for unregistered fields', function () {
+    $registry = new FieldHandlerRegistry();
+    $field = new PlainText();
+
+    expect($registry->getHandler($field))->toBeNull();
+    expect($registry->getTypeKey($field))->toBe('generic');
+});
+
+it('matches subclasses via is_a', function () {
+    \yii\base\Event::on(
+        FieldHandlerRegistry::class,
+        FieldHandlerRegistry::EVENT_REGISTER_HANDLERS,
+        function (RegisterFieldHandlersEvent $event) {
+            $event->handlers[] = PlainHandlerStub::class;
+        }
+    );
+
+    // Anonymous subclass of PlainText
+    $subclass = new class extends PlainText {};
+
+    $registry = new FieldHandlerRegistry();
+    $handler = $registry->getHandler($subclass);
+
+    expect($handler)->toBeInstanceOf(PlainHandlerStub::class);
+});
+
+it('caches registration (only fires event once)', function () {
+    $fireCount = 0;
+    \yii\base\Event::on(
+        FieldHandlerRegistry::class,
+        FieldHandlerRegistry::EVENT_REGISTER_HANDLERS,
+        function (RegisterFieldHandlersEvent $event) use (&$fireCount) {
+            $fireCount++;
+            $event->handlers[] = PlainHandlerStub::class;
+        }
+    );
+
+    $registry = new FieldHandlerRegistry();
+    $field = new PlainText();
+
+    $registry->getHandler($field);
+    $registry->getHandler($field);
+    $registry->getTypeKey($field);
+
+    expect($fireCount)->toBe(1);
+});
+
+it('can be reset', function () {
+    $fireCount = 0;
+    \yii\base\Event::on(
+        FieldHandlerRegistry::class,
+        FieldHandlerRegistry::EVENT_REGISTER_HANDLERS,
+        function (RegisterFieldHandlersEvent $event) use (&$fireCount) {
+            $fireCount++;
+            $event->handlers[] = PlainHandlerStub::class;
+        }
+    );
+
+    $registry = new FieldHandlerRegistry();
+    $field = new PlainText();
+
+    $registry->getHandler($field);
+    expect($fireCount)->toBe(1);
+
+    $registry->reset();
+    $registry->getHandler($field);
+    expect($fireCount)->toBe(2);
+});
+
+it('skips handlers that do not implement the interface', function () {
+    \yii\base\Event::on(
+        FieldHandlerRegistry::class,
+        FieldHandlerRegistry::EVENT_REGISTER_HANDLERS,
+        function (RegisterFieldHandlersEvent $event) {
+            $event->handlers[] = BogusHandlerStub::class;
+        }
+    );
+
+    $registry = new FieldHandlerRegistry();
+    $field = new PlainText();
+
+    expect($registry->getHandler($field))->toBeNull();
+});


### PR DESCRIPTION
Part of the v3 refactor stack for [FRE-56](https://linear.app/sanity/issue/FRE-56). Closes [FRE-125](https://linear.app/sanity/issue/fre-125).


**Diff:** 12 files changed, 896 insertions(+), 2 deletions(-)
**Tests:** 69 → 69 (+0 (refactor))
**Verified on fresh DB:** `DROP DATABASE; pest` green

### Stack navigation

↑ Builds on **#90** `foundation-enum-json` (P1.1)
↓ Followed by **#92** `field-handlers-native-third-party` (P1.3)

### Review notes

- Single-commit branch — review the commit, not just the diff
- BC preserved — old `AuditService` API still works via @deprecated delegators
- This is a **draft** — not a request to merge yet. Marked ready when the stack is approved end-to-end.

