### PR TITLE
Phase 1.3 — Field handlers: 15 handlers for native + third-party fields

### DIFF
--- a/src/Audit.php
+++ b/src/Audit.php
@@ -44,6 +44,22 @@ use craft\services\UserPermissions;
 use craft\services\Users;
 use craft\web\twig\variables\CraftVariable;
 use craft\web\UrlManager;
+use superbig\audit\events\RegisterFieldHandlersEvent;
+use superbig\audit\fieldHandlers\handlers\BooleanHandler;
+use superbig\audit\fieldHandlers\handlers\ColorHandler;
+use superbig\audit\fieldHandlers\handlers\DateHandler;
+use superbig\audit\fieldHandlers\handlers\MatrixHandler;
+use superbig\audit\fieldHandlers\handlers\MoneyHandler;
+use superbig\audit\fieldHandlers\handlers\MultiOptionHandler;
+use superbig\audit\fieldHandlers\handlers\NeoHandler;
+use superbig\audit\fieldHandlers\handlers\OptionHandler;
+use superbig\audit\fieldHandlers\handlers\PlainHandler;
+use superbig\audit\fieldHandlers\handlers\RelationHandler;
+use superbig\audit\fieldHandlers\handlers\RichTextHandler;
+use superbig\audit\fieldHandlers\handlers\SeoHandler;
+use superbig\audit\fieldHandlers\handlers\SuperTableHandler;
+use superbig\audit\fieldHandlers\handlers\TableHandler;
+use superbig\audit\fieldHandlers\handlers\VizyHandler;
 use superbig\audit\models\AuditModel;
 use superbig\audit\models\Settings;
 use superbig\audit\services\Audit_GeoService;
@@ -124,6 +140,8 @@ class Audit extends Plugin
             'fieldDiffService' => FieldDiffService::class,
             'auditRecorder' => AuditRecorder::class,
         ]);
+
+        $this->registerFieldHandlers();
 
         Event::on(
             Plugins::class,
@@ -481,6 +499,38 @@ class Audit extends Plugin
         );
 
         $this->setupQueueEvents();
+    }
+
+    /**
+     * Register the built-in field handlers with the FieldHandlerRegistry.
+     * Third-party plugin handlers gate themselves via class_exists() inside
+     * supportedFields(), so they register safely even when the plugin is missing.
+     */
+    protected function registerFieldHandlers(): void
+    {
+        Event::on(
+            FieldHandlerRegistry::class,
+            FieldHandlerRegistry::EVENT_REGISTER_HANDLERS,
+            static function(RegisterFieldHandlersEvent $event) {
+                $event->handlers = array_merge($event->handlers, [
+                    PlainHandler::class,
+                    ColorHandler::class,
+                    RichTextHandler::class,
+                    DateHandler::class,
+                    BooleanHandler::class,
+                    OptionHandler::class,
+                    MultiOptionHandler::class,
+                    RelationHandler::class,
+                    MoneyHandler::class,
+                    TableHandler::class,
+                    MatrixHandler::class,
+                    NeoHandler::class,
+                    SuperTableHandler::class,
+                    VizyHandler::class,
+                    SeoHandler::class,
+                ]);
+            }
+        );
     }
 
     public function setupPermissions()

--- a/src/fieldHandlers/handlers/BooleanHandler.php
+++ b/src/fieldHandlers/handlers/BooleanHandler.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace superbig\audit\fieldHandlers\handlers;
+
+use craft\base\ElementInterface;
+use craft\base\FieldInterface;
+use craft\fields\Lightswitch;
+use superbig\audit\fieldHandlers\FieldHandler;
+
+/**
+ * Handler for Lightswitch (boolean) fields.
+ */
+class BooleanHandler implements FieldHandler
+{
+    public static function supportedFields(): array
+    {
+        return [Lightswitch::class];
+    }
+
+    public static function typeKey(): string
+    {
+        return 'boolean';
+    }
+
+    public function normalize(FieldInterface $field, mixed $rawValue, ElementInterface $element): mixed
+    {
+        return (bool) $rawValue;
+    }
+}

--- a/src/fieldHandlers/handlers/ColorHandler.php
+++ b/src/fieldHandlers/handlers/ColorHandler.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace superbig\audit\fieldHandlers\handlers;
+
+use craft\base\ElementInterface;
+use craft\base\FieldInterface;
+use craft\fields\Color;
+use superbig\audit\fieldHandlers\FieldHandler;
+
+/**
+ * Handler for Color field. Normalizes to a hex string for swatch rendering.
+ */
+class ColorHandler implements FieldHandler
+{
+    public static function supportedFields(): array
+    {
+        return [Color::class];
+    }
+
+    public static function typeKey(): string
+    {
+        return 'color';
+    }
+
+    public function normalize(FieldInterface $field, mixed $rawValue, ElementInterface $element): mixed
+    {
+        if ($rawValue === null || $rawValue === '') {
+            return null;
+        }
+        if (is_object($rawValue) && isset($rawValue->hex)) {
+            return (string) $rawValue->hex;
+        }
+        return (string) $rawValue;
+    }
+}

--- a/src/fieldHandlers/handlers/DateHandler.php
+++ b/src/fieldHandlers/handlers/DateHandler.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace superbig\audit\fieldHandlers\handlers;
+
+use craft\base\ElementInterface;
+use craft\base\FieldInterface;
+use craft\fields\Date;
+use craft\fields\Time;
+use superbig\audit\fieldHandlers\FieldHandler;
+
+/**
+ * Handler for Date and Time fields.
+ */
+class DateHandler implements FieldHandler
+{
+    public static function supportedFields(): array
+    {
+        return [
+            Date::class,
+            Time::class,
+        ];
+    }
+
+    public static function typeKey(): string
+    {
+        return 'date';
+    }
+
+    public function normalize(FieldInterface $field, mixed $rawValue, ElementInterface $element): mixed
+    {
+        if (!$rawValue instanceof \DateTime) {
+            return null;
+        }
+        if ($field instanceof Time) {
+            return $rawValue->format('H:i:s');
+        }
+        $showTime = $field->showTime ?? false;
+        return $showTime ? $rawValue->format('Y-m-d H:i:s') : $rawValue->format('Y-m-d');
+    }
+}

--- a/src/fieldHandlers/handlers/MatrixHandler.php
+++ b/src/fieldHandlers/handlers/MatrixHandler.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace superbig\audit\fieldHandlers\handlers;
+
+use craft\base\ElementInterface;
+use craft\base\FieldInterface;
+use craft\fields\Matrix;
+use superbig\audit\fieldHandlers\FieldHandler;
+
+/**
+ * Handler for Matrix fields. In Craft 5, Matrix entries are nested elements.
+ */
+class MatrixHandler implements FieldHandler
+{
+    public static function supportedFields(): array
+    {
+        return [Matrix::class];
+    }
+
+    public static function typeKey(): string
+    {
+        return 'matrix';
+    }
+
+    public function normalize(FieldInterface $field, mixed $rawValue, ElementInterface $element): mixed
+    {
+        if (!is_object($rawValue) || !method_exists($rawValue, 'all')) {
+            if (is_iterable($rawValue)) {
+                $entries = is_array($rawValue) ? $rawValue : iterator_to_array($rawValue);
+            } else {
+                return [];
+            }
+        } else {
+            $query = clone $rawValue;
+            if (method_exists($query, 'status')) {
+                $query->status(null);
+            }
+            $entries = $query->all();
+        }
+
+        return array_values(array_map(function($entry) {
+            return [
+                'id' => $entry->id ?? null,
+                'type' => $entry->type->handle ?? null,
+                'typeName' => $entry->type->name ?? null,
+                'title' => $entry->title ?? null,
+                'enabled' => (bool) ($entry->enabled ?? false),
+                'fields' => method_exists($entry, 'getSerializedFieldValues')
+                    ? $entry->getSerializedFieldValues()
+                    : [],
+            ];
+        }, array_filter($entries, fn($e) => is_object($e))));
+    }
+}

--- a/src/fieldHandlers/handlers/MoneyHandler.php
+++ b/src/fieldHandlers/handlers/MoneyHandler.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace superbig\audit\fieldHandlers\handlers;
+
+use craft\base\ElementInterface;
+use craft\base\FieldInterface;
+use craft\fields\Money;
+use superbig\audit\fieldHandlers\FieldHandler;
+
+/**
+ * Handler for Money fields. Stores amount (integer cents), currency, and display string.
+ */
+class MoneyHandler implements FieldHandler
+{
+    public static function supportedFields(): array
+    {
+        return [Money::class];
+    }
+
+    public static function typeKey(): string
+    {
+        return 'money';
+    }
+
+    public function normalize(FieldInterface $field, mixed $rawValue, ElementInterface $element): mixed
+    {
+        if ($rawValue === null) {
+            return null;
+        }
+
+        $currency = $field->currency ?? 'USD';
+
+        if (is_object($rawValue) && method_exists($rawValue, 'getAmount')) {
+            $amount = (int) ($rawValue->getAmount() ?? 0);
+        } else {
+            $amount = (int) $rawValue;
+        }
+
+        return [
+            'amount' => $amount,
+            'currency' => $currency,
+            'display' => number_format($amount / 100, 2) . ' ' . $currency,
+        ];
+    }
+}

--- a/src/fieldHandlers/handlers/MultiOptionHandler.php
+++ b/src/fieldHandlers/handlers/MultiOptionHandler.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace superbig\audit\fieldHandlers\handlers;
+
+use craft\base\ElementInterface;
+use craft\base\FieldInterface;
+use craft\fields\Checkboxes;
+use craft\fields\MultiSelect;
+use superbig\audit\fieldHandlers\FieldHandler;
+
+/**
+ * Handler for multi-option fields (Checkboxes, MultiSelect).
+ * Returns an array of {value, label} for options where selected === true.
+ */
+class MultiOptionHandler implements FieldHandler
+{
+    public static function supportedFields(): array
+    {
+        return [
+            Checkboxes::class,
+            MultiSelect::class,
+        ];
+    }
+
+    public static function typeKey(): string
+    {
+        return 'multi-option';
+    }
+
+    public function normalize(FieldInterface $field, mixed $rawValue, ElementInterface $element): mixed
+    {
+        $selected = [];
+        if (!$rawValue) {
+            return $selected;
+        }
+
+        if (!is_iterable($rawValue)) {
+            return $selected;
+        }
+
+        foreach ($rawValue as $option) {
+            if (is_object($option) && !empty($option->selected ?? false)) {
+                $selected[] = [
+                    'value' => $option->value ?? null,
+                    'label' => $option->label ?? null,
+                ];
+            }
+        }
+        return $selected;
+    }
+}

--- a/src/fieldHandlers/handlers/NeoHandler.php
+++ b/src/fieldHandlers/handlers/NeoHandler.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace superbig\audit\fieldHandlers\handlers;
+
+use craft\base\ElementInterface;
+use craft\base\FieldInterface;
+use superbig\audit\fieldHandlers\FieldHandler;
+
+/**
+ * Handler for Neo fields (benf/craft-neo). Plugin may not be installed —
+ * supportedFields() returns [] in that case so the handler registers safely.
+ *
+ * Neo blocks support nested levels via $block->level.
+ */
+class NeoHandler implements FieldHandler
+{
+    public static function supportedFields(): array
+    {
+        return class_exists('benf\\neo\\Field') ? ['benf\\neo\\Field'] : [];
+    }
+
+    public static function typeKey(): string
+    {
+        return 'neo';
+    }
+
+    public function normalize(FieldInterface $field, mixed $rawValue, ElementInterface $element): mixed
+    {
+        if (!is_object($rawValue) || !method_exists($rawValue, 'all')) {
+            return [];
+        }
+
+        $query = clone $rawValue;
+        if (method_exists($query, 'status')) {
+            $query->status(null);
+        }
+        $blocks = $query->all();
+
+        return array_values(array_map(function($block) {
+            return [
+                'id' => $block->id ?? null,
+                'level' => $block->level ?? 1,
+                'type' => $block->type->handle ?? null,
+                'typeName' => $block->type->name ?? null,
+                'enabled' => (bool) ($block->enabled ?? false),
+                'fields' => method_exists($block, 'getSerializedFieldValues')
+                    ? $block->getSerializedFieldValues()
+                    : [],
+            ];
+        }, array_filter($blocks, fn($b) => is_object($b))));
+    }
+}

--- a/src/fieldHandlers/handlers/OptionHandler.php
+++ b/src/fieldHandlers/handlers/OptionHandler.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace superbig\audit\fieldHandlers\handlers;
+
+use craft\base\ElementInterface;
+use craft\base\FieldInterface;
+use craft\fields\Dropdown;
+use craft\fields\RadioButtons;
+use superbig\audit\fieldHandlers\FieldHandler;
+
+/**
+ * Handler for single-option fields (Dropdown, RadioButtons).
+ * Stores {value, label} so diffs show both machine and human-readable forms.
+ */
+class OptionHandler implements FieldHandler
+{
+    public static function supportedFields(): array
+    {
+        return [
+            Dropdown::class,
+            RadioButtons::class,
+        ];
+    }
+
+    public static function typeKey(): string
+    {
+        return 'option';
+    }
+
+    public function normalize(FieldInterface $field, mixed $rawValue, ElementInterface $element): mixed
+    {
+        if ($rawValue === null) {
+            return null;
+        }
+        if (is_object($rawValue)) {
+            return [
+                'value' => $rawValue->value ?? null,
+                'label' => $rawValue->label ?? null,
+            ];
+        }
+        return ['value' => $rawValue, 'label' => $rawValue];
+    }
+}

--- a/src/fieldHandlers/handlers/PlainHandler.php
+++ b/src/fieldHandlers/handlers/PlainHandler.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace superbig\audit\fieldHandlers\handlers;
+
+use craft\base\ElementInterface;
+use craft\base\FieldInterface;
+use craft\fields\Email;
+use craft\fields\Number;
+use craft\fields\PlainText;
+use craft\fields\Url;
+use superbig\audit\fieldHandlers\FieldHandler;
+
+/**
+ * Handler for plain scalar-like fields: PlainText, Number, Email, Url.
+ */
+class PlainHandler implements FieldHandler
+{
+    public static function supportedFields(): array
+    {
+        return [
+            PlainText::class,
+            Number::class,
+            Email::class,
+            Url::class,
+        ];
+    }
+
+    public static function typeKey(): string
+    {
+        return 'plain';
+    }
+
+    public function normalize(FieldInterface $field, mixed $rawValue, ElementInterface $element): mixed
+    {
+        if ($rawValue === null) {
+            return null;
+        }
+        return is_scalar($rawValue) ? $rawValue : (string) $rawValue;
+    }
+}

--- a/src/fieldHandlers/handlers/RelationHandler.php
+++ b/src/fieldHandlers/handlers/RelationHandler.php
@@ -1,0 +1,77 @@
+<?php
+
+namespace superbig\audit\fieldHandlers\handlers;
+
+use craft\base\ElementInterface;
+use craft\base\FieldInterface;
+use craft\fields\Addresses;
+use craft\fields\Assets;
+use craft\fields\Categories;
+use craft\fields\Entries;
+use craft\fields\Tags;
+use craft\fields\Users;
+use superbig\audit\fieldHandlers\FieldHandler;
+
+/**
+ * Handler for relation fields — Entries, Assets, Categories, Tags, Users, Addresses.
+ * Normalizes to a list of {id, title, type, status}.
+ */
+class RelationHandler implements FieldHandler
+{
+    public static function supportedFields(): array
+    {
+        return [
+            Entries::class,
+            Assets::class,
+            Categories::class,
+            Tags::class,
+            Users::class,
+            Addresses::class,
+        ];
+    }
+
+    public static function typeKey(): string
+    {
+        return 'relation';
+    }
+
+    public function normalize(FieldInterface $field, mixed $rawValue, ElementInterface $element): mixed
+    {
+        if (!$rawValue) {
+            return [];
+        }
+
+        if (is_object($rawValue) && method_exists($rawValue, 'all')) {
+            // ElementQuery — clone so we don't mutate shared state.
+            $query = clone $rawValue;
+            if (method_exists($query, 'status')) {
+                $query->status(null);
+            }
+            $elements = $query->all();
+        } elseif (is_iterable($rawValue)) {
+            $elements = is_array($rawValue) ? $rawValue : iterator_to_array($rawValue);
+        } else {
+            $elements = [$rawValue];
+        }
+
+        $elements = array_values(array_filter($elements, fn($el) => is_object($el)));
+
+        return array_map(function($el) {
+            $title = null;
+            if (isset($el->title)) {
+                $title = $el->title;
+            } elseif (isset($el->name)) {
+                $title = $el->name;
+            } else {
+                $title = (string) $el;
+            }
+
+            return [
+                'id' => $el->id ?? null,
+                'title' => $title,
+                'type' => method_exists($el, 'displayName') ? $el::displayName() : get_class($el),
+                'status' => method_exists($el, 'getStatus') ? $el->getStatus() : null,
+            ];
+        }, $elements);
+    }
+}

--- a/src/fieldHandlers/handlers/RichTextHandler.php
+++ b/src/fieldHandlers/handlers/RichTextHandler.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace superbig\audit\fieldHandlers\handlers;
+
+use craft\base\ElementInterface;
+use craft\base\FieldInterface;
+use superbig\audit\fieldHandlers\FieldHandler;
+
+/**
+ * Handler for rich-text fields from CKEditor, Redactor, and TinyMCE plugins.
+ * Fields are gated behind class_exists() so the handler registers safely even
+ * when none of the plugins are installed.
+ */
+class RichTextHandler implements FieldHandler
+{
+    public static function supportedFields(): array
+    {
+        return array_values(array_filter([
+            'craft\\ckeditor\\Field',
+            'craft\\redactor\\Field',
+            'craft\\tinymce\\Field',
+        ], 'class_exists'));
+    }
+
+    public static function typeKey(): string
+    {
+        return 'richtext';
+    }
+
+    public function normalize(FieldInterface $field, mixed $rawValue, ElementInterface $element): mixed
+    {
+        if ($rawValue === null) {
+            return null;
+        }
+        return (string) $rawValue;
+    }
+}

--- a/src/fieldHandlers/handlers/SeoHandler.php
+++ b/src/fieldHandlers/handlers/SeoHandler.php
@@ -1,0 +1,63 @@
+<?php
+
+namespace superbig\audit\fieldHandlers\handlers;
+
+use craft\base\ElementInterface;
+use craft\base\FieldInterface;
+use superbig\audit\fieldHandlers\FieldHandler;
+
+/**
+ * Handler for SEO fields (ether/craft-seo). Normalizes title, description,
+ * keywords, social, and robots for readable diffs.
+ */
+class SeoHandler implements FieldHandler
+{
+    public static function supportedFields(): array
+    {
+        return class_exists('ether\\seo\\fields\\SeoField')
+            ? ['ether\\seo\\fields\\SeoField']
+            : [];
+    }
+
+    public static function typeKey(): string
+    {
+        return 'seo';
+    }
+
+    public function normalize(FieldInterface $field, mixed $rawValue, ElementInterface $element): mixed
+    {
+        if ($rawValue === null) {
+            return null;
+        }
+
+        $get = static function($src, string $key, $default = null) {
+            if (is_array($src)) {
+                return $src[$key] ?? $default;
+            }
+            if (is_object($src)) {
+                return $src->{$key} ?? $default;
+            }
+            return $default;
+        };
+
+        $title = $get($rawValue, 'title');
+        $description = $get($rawValue, 'description');
+        $keywords = $get($rawValue, 'keywords', []);
+        $social = $get($rawValue, 'social', []);
+        $advanced = $get($rawValue, 'advanced', []);
+        $robots = $get($rawValue, 'robots', $get($advanced, 'robots', []));
+
+        // Keywords may be array of {keyword, rating}
+        if (is_object($keywords)) {
+            $keywords = (array) $keywords;
+        }
+
+        return [
+            'title' => is_scalar($title) ? (string) $title : $title,
+            'description' => is_scalar($description) ? (string) $description : $description,
+            'keywords' => $keywords,
+            'social' => is_object($social) ? (array) $social : $social,
+            'robots' => is_object($robots) ? (array) $robots : $robots,
+        ];
+    }
+}

--- a/src/fieldHandlers/handlers/SuperTableHandler.php
+++ b/src/fieldHandlers/handlers/SuperTableHandler.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace superbig\audit\fieldHandlers\handlers;
+
+use craft\base\ElementInterface;
+use craft\base\FieldInterface;
+use superbig\audit\fieldHandlers\FieldHandler;
+
+/**
+ * Handler for Super Table fields (verbb/super-table).
+ */
+class SuperTableHandler implements FieldHandler
+{
+    public static function supportedFields(): array
+    {
+        return class_exists('verbb\\supertable\\fields\\SuperTableField')
+            ? ['verbb\\supertable\\fields\\SuperTableField']
+            : [];
+    }
+
+    public static function typeKey(): string
+    {
+        return 'supertable';
+    }
+
+    public function normalize(FieldInterface $field, mixed $rawValue, ElementInterface $element): mixed
+    {
+        if (!is_object($rawValue) || !method_exists($rawValue, 'all')) {
+            return [];
+        }
+
+        $query = clone $rawValue;
+        if (method_exists($query, 'status')) {
+            $query->status(null);
+        }
+        $rows = $query->all();
+
+        return array_values(array_map(function($row) {
+            return [
+                'id' => $row->id ?? null,
+                'enabled' => (bool) ($row->enabled ?? false),
+                'fields' => method_exists($row, 'getSerializedFieldValues')
+                    ? $row->getSerializedFieldValues()
+                    : [],
+            ];
+        }, array_filter($rows, fn($r) => is_object($r))));
+    }
+}

--- a/src/fieldHandlers/handlers/TableHandler.php
+++ b/src/fieldHandlers/handlers/TableHandler.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace superbig\audit\fieldHandlers\handlers;
+
+use craft\base\ElementInterface;
+use craft\base\FieldInterface;
+use craft\fields\Table;
+use superbig\audit\fieldHandlers\FieldHandler;
+
+/**
+ * Handler for Table fields. Returns rows keyed by column heading for readable diffs.
+ */
+class TableHandler implements FieldHandler
+{
+    public static function supportedFields(): array
+    {
+        return [Table::class];
+    }
+
+    public static function typeKey(): string
+    {
+        return 'table';
+    }
+
+    public function normalize(FieldInterface $field, mixed $rawValue, ElementInterface $element): mixed
+    {
+        if (!is_array($rawValue)) {
+            return [];
+        }
+        $columns = $field->columns ?? [];
+
+        return array_values(array_map(function($row) use ($columns) {
+            $labeled = [];
+            if (!is_array($row)) {
+                return $labeled;
+            }
+            foreach ($columns as $handle => $col) {
+                $heading = is_array($col) ? ($col['heading'] ?? $handle) : $handle;
+                $labeled[$heading] = $row[$handle] ?? null;
+            }
+            // If no columns defined, fall through to the row as-is.
+            return $columns ? $labeled : $row;
+        }, $rawValue));
+    }
+}

--- a/src/fieldHandlers/handlers/VizyHandler.php
+++ b/src/fieldHandlers/handlers/VizyHandler.php
@@ -1,0 +1,86 @@
+<?php
+
+namespace superbig\audit\fieldHandlers\handlers;
+
+use craft\base\ElementInterface;
+use craft\base\FieldInterface;
+use superbig\audit\fieldHandlers\FieldHandler;
+
+/**
+ * Handler for Vizy fields (verbb/vizy). Vizy stores mixed text nodes and block nodes,
+ * so we normalize to a list of nodes preserving type, marks, and nested block fields.
+ */
+class VizyHandler implements FieldHandler
+{
+    public static function supportedFields(): array
+    {
+        return class_exists('verbb\\vizy\\fields\\VizyField')
+            ? ['verbb\\vizy\\fields\\VizyField']
+            : [];
+    }
+
+    public static function typeKey(): string
+    {
+        return 'vizy';
+    }
+
+    public function normalize(FieldInterface $field, mixed $rawValue, ElementInterface $element): mixed
+    {
+        if ($rawValue === null) {
+            return [];
+        }
+
+        // VizyNodeCollection / NodeCollection — iterate and serialize each node.
+        $nodes = [];
+        if (is_iterable($rawValue)) {
+            foreach ($rawValue as $node) {
+                $nodes[] = $this->serializeNode($node);
+            }
+        } elseif (is_object($rawValue) && method_exists($rawValue, 'getNodes')) {
+            foreach ($rawValue->getNodes() as $node) {
+                $nodes[] = $this->serializeNode($node);
+            }
+        }
+
+        return $nodes;
+    }
+
+    private function serializeNode(mixed $node): array
+    {
+        if (!is_object($node)) {
+            return ['type' => 'unknown', 'value' => $node];
+        }
+
+        // Try serialize() first — Vizy nodes usually provide it.
+        if (method_exists($node, 'serializeValue')) {
+            $serialized = $node->serializeValue();
+            if (is_array($serialized)) {
+                return $serialized;
+            }
+        }
+        if (method_exists($node, 'getRawNode')) {
+            $raw = $node->getRawNode();
+            if (is_array($raw)) {
+                return $raw;
+            }
+        }
+
+        // Fallback: introspect common properties.
+        $out = [
+            'type' => $node->type ?? (method_exists($node, 'getType') ? $node->getType() : 'unknown'),
+        ];
+        if (isset($node->content)) {
+            $out['content'] = $node->content;
+        }
+        if (isset($node->marks)) {
+            $out['marks'] = $node->marks;
+        }
+        if (isset($node->attrs)) {
+            $out['attrs'] = $node->attrs;
+        }
+        if (method_exists($node, 'getSerializedFieldValues')) {
+            $out['fields'] = $node->getSerializedFieldValues();
+        }
+        return $out;
+    }
+}

--- a/tests/Unit/FieldHandlerTest.php
+++ b/tests/Unit/FieldHandlerTest.php
@@ -1,0 +1,376 @@
+<?php
+
+use craft\elements\Entry;
+use craft\fields\Assets;
+use craft\fields\Categories;
+use craft\fields\Checkboxes;
+use craft\fields\Color;
+use craft\fields\Date;
+use craft\fields\Dropdown;
+use craft\fields\Email;
+use craft\fields\Entries;
+use craft\fields\Lightswitch;
+use craft\fields\Matrix;
+use craft\fields\Money;
+use craft\fields\MultiSelect;
+use craft\fields\Number;
+use craft\fields\PlainText;
+use craft\fields\RadioButtons;
+use craft\fields\Table;
+use craft\fields\Tags;
+use craft\fields\Time;
+use craft\fields\Url;
+use craft\fields\Users;
+use superbig\audit\Audit;
+use superbig\audit\fieldHandlers\handlers\BooleanHandler;
+use superbig\audit\fieldHandlers\handlers\ColorHandler;
+use superbig\audit\fieldHandlers\handlers\DateHandler;
+use superbig\audit\fieldHandlers\handlers\MatrixHandler;
+use superbig\audit\fieldHandlers\handlers\MoneyHandler;
+use superbig\audit\fieldHandlers\handlers\MultiOptionHandler;
+use superbig\audit\fieldHandlers\handlers\NeoHandler;
+use superbig\audit\fieldHandlers\handlers\OptionHandler;
+use superbig\audit\fieldHandlers\handlers\PlainHandler;
+use superbig\audit\fieldHandlers\handlers\RelationHandler;
+use superbig\audit\fieldHandlers\handlers\RichTextHandler;
+use superbig\audit\fieldHandlers\handlers\SeoHandler;
+use superbig\audit\fieldHandlers\handlers\SuperTableHandler;
+use superbig\audit\fieldHandlers\handlers\TableHandler;
+use superbig\audit\fieldHandlers\handlers\VizyHandler;
+
+// --- typeKey() & supportedFields() sanity checks --------------------------
+
+it('PlainHandler exposes type key and supported fields', function () {
+    expect(PlainHandler::typeKey())->toBe('plain');
+    expect(PlainHandler::supportedFields())->toEqual([
+        PlainText::class,
+        Number::class,
+        Email::class,
+        Url::class,
+    ]);
+});
+
+it('ColorHandler exposes type key and supported fields', function () {
+    expect(ColorHandler::typeKey())->toBe('color');
+    expect(ColorHandler::supportedFields())->toEqual([Color::class]);
+});
+
+it('DateHandler exposes type key and supported fields', function () {
+    expect(DateHandler::typeKey())->toBe('date');
+    expect(DateHandler::supportedFields())->toEqual([Date::class, Time::class]);
+});
+
+it('BooleanHandler exposes type key and supported fields', function () {
+    expect(BooleanHandler::typeKey())->toBe('boolean');
+    expect(BooleanHandler::supportedFields())->toEqual([Lightswitch::class]);
+});
+
+it('OptionHandler exposes type key and supported fields', function () {
+    expect(OptionHandler::typeKey())->toBe('option');
+    expect(OptionHandler::supportedFields())->toEqual([Dropdown::class, RadioButtons::class]);
+});
+
+it('MultiOptionHandler exposes type key and supported fields', function () {
+    expect(MultiOptionHandler::typeKey())->toBe('multi-option');
+    expect(MultiOptionHandler::supportedFields())->toEqual([Checkboxes::class, MultiSelect::class]);
+});
+
+it('RelationHandler exposes type key and supported fields', function () {
+    expect(RelationHandler::typeKey())->toBe('relation');
+    expect(RelationHandler::supportedFields())->toContain(Entries::class);
+    expect(RelationHandler::supportedFields())->toContain(Assets::class);
+    expect(RelationHandler::supportedFields())->toContain(Categories::class);
+    expect(RelationHandler::supportedFields())->toContain(Tags::class);
+    expect(RelationHandler::supportedFields())->toContain(Users::class);
+});
+
+it('MoneyHandler exposes type key and supported fields', function () {
+    expect(MoneyHandler::typeKey())->toBe('money');
+    expect(MoneyHandler::supportedFields())->toEqual([Money::class]);
+});
+
+it('TableHandler exposes type key and supported fields', function () {
+    expect(TableHandler::typeKey())->toBe('table');
+    expect(TableHandler::supportedFields())->toEqual([Table::class]);
+});
+
+it('MatrixHandler exposes type key and supported fields', function () {
+    expect(MatrixHandler::typeKey())->toBe('matrix');
+    expect(MatrixHandler::supportedFields())->toEqual([Matrix::class]);
+});
+
+// --- RichText: class_exists gating ---------------------------------------
+
+it('RichTextHandler gates supported fields behind class_exists', function () {
+    expect(RichTextHandler::typeKey())->toBe('richtext');
+    // In test env none of CKEditor/Redactor/TinyMCE are installed.
+    $supported = RichTextHandler::supportedFields();
+    expect($supported)->toBeArray();
+    foreach ($supported as $cls) {
+        expect(class_exists($cls))->toBeTrue();
+    }
+});
+
+// --- Third-party: return [] when plugin absent ---------------------------
+
+it('third-party handlers return empty supportedFields when plugins absent', function () {
+    // None of these plugins should be installed in the test env.
+    expect(NeoHandler::typeKey())->toBe('neo');
+    expect(NeoHandler::supportedFields())->toBe(class_exists('benf\\neo\\Field') ? ['benf\\neo\\Field'] : []);
+
+    expect(SuperTableHandler::typeKey())->toBe('supertable');
+    expect(SuperTableHandler::supportedFields())->toBe(
+        class_exists('verbb\\supertable\\fields\\SuperTableField')
+            ? ['verbb\\supertable\\fields\\SuperTableField']
+            : []
+    );
+
+    expect(VizyHandler::typeKey())->toBe('vizy');
+    expect(VizyHandler::supportedFields())->toBe(
+        class_exists('verbb\\vizy\\fields\\VizyField')
+            ? ['verbb\\vizy\\fields\\VizyField']
+            : []
+    );
+
+    expect(SeoHandler::typeKey())->toBe('seo');
+    expect(SeoHandler::supportedFields())->toBe(
+        class_exists('ether\\seo\\fields\\SeoField')
+            ? ['ether\\seo\\fields\\SeoField']
+            : []
+    );
+});
+
+// --- normalize() coverage ------------------------------------------------
+
+it('PlainHandler normalizes scalars and objects', function () {
+    $field = new PlainText();
+    $element = new Entry();
+    $h = new PlainHandler();
+
+    expect($h->normalize($field, 'hello', $element))->toBe('hello');
+    expect($h->normalize($field, 42, $element))->toBe(42);
+    expect($h->normalize($field, null, $element))->toBeNull();
+    // Stringable object
+    $stringable = new class {
+        public function __toString(): string { return 'obj'; }
+    };
+    expect($h->normalize($field, $stringable, $element))->toBe('obj');
+});
+
+it('ColorHandler handles ColorData-like objects and strings', function () {
+    $field = new Color();
+    $element = new Entry();
+    $h = new ColorHandler();
+
+    expect($h->normalize($field, null, $element))->toBeNull();
+    expect($h->normalize($field, '', $element))->toBeNull();
+    expect($h->normalize($field, '#ff0000', $element))->toBe('#ff0000');
+
+    $color = (object) ['hex' => '#00ff00'];
+    expect($h->normalize($field, $color, $element))->toBe('#00ff00');
+});
+
+it('BooleanHandler coerces all values to bool', function () {
+    $field = new Lightswitch();
+    $element = new Entry();
+    $h = new BooleanHandler();
+
+    expect($h->normalize($field, true, $element))->toBeTrue();
+    expect($h->normalize($field, false, $element))->toBeFalse();
+    expect($h->normalize($field, 1, $element))->toBeTrue();
+    expect($h->normalize($field, 0, $element))->toBeFalse();
+    expect($h->normalize($field, '1', $element))->toBeTrue();
+    expect($h->normalize($field, '', $element))->toBeFalse();
+    expect($h->normalize($field, null, $element))->toBeFalse();
+});
+
+it('DateHandler formats Date vs Time fields differently', function () {
+    $element = new Entry();
+    $h = new DateHandler();
+
+    $dt = new \DateTime('2025-06-15 14:30:45');
+
+    $dateField = new Date();
+    $dateField->showTime = false;
+    expect($h->normalize($dateField, $dt, $element))->toBe('2025-06-15');
+
+    $dateTimeField = new Date();
+    $dateTimeField->showTime = true;
+    expect($h->normalize($dateTimeField, $dt, $element))->toBe('2025-06-15 14:30:45');
+
+    $timeField = new Time();
+    expect($h->normalize($timeField, $dt, $element))->toBe('14:30:45');
+
+    expect($h->normalize($dateField, null, $element))->toBeNull();
+    expect($h->normalize($dateField, 'not-a-date', $element))->toBeNull();
+});
+
+it('OptionHandler normalizes SingleOptionFieldData-like objects', function () {
+    $field = new Dropdown();
+    $element = new Entry();
+    $h = new OptionHandler();
+
+    expect($h->normalize($field, null, $element))->toBeNull();
+
+    $opt = (object) ['value' => 'red', 'label' => 'Red'];
+    expect($h->normalize($field, $opt, $element))->toBe(['value' => 'red', 'label' => 'Red']);
+
+    // Fallback for scalar
+    expect($h->normalize($field, 'blue', $element))->toBe(['value' => 'blue', 'label' => 'blue']);
+});
+
+it('MultiOptionHandler returns only selected options', function () {
+    $field = new Checkboxes();
+    $element = new Entry();
+    $h = new MultiOptionHandler();
+
+    $options = [
+        (object) ['value' => 'a', 'label' => 'A', 'selected' => true],
+        (object) ['value' => 'b', 'label' => 'B', 'selected' => false],
+        (object) ['value' => 'c', 'label' => 'C', 'selected' => true],
+    ];
+    expect($h->normalize($field, $options, $element))->toBe([
+        ['value' => 'a', 'label' => 'A'],
+        ['value' => 'c', 'label' => 'C'],
+    ]);
+
+    expect($h->normalize($field, null, $element))->toBe([]);
+    expect($h->normalize($field, [], $element))->toBe([]);
+});
+
+it('RelationHandler normalizes element-like objects', function () {
+    $field = new Entries();
+    $element = new Entry();
+    $h = new RelationHandler();
+
+    expect($h->normalize($field, null, $element))->toBe([]);
+    expect($h->normalize($field, [], $element))->toBe([]);
+
+    // Fake element class with displayName + getStatus
+    $fakeEl = new class {
+        public int $id = 42;
+        public string $title = 'Hello';
+        public static function displayName(): string { return 'FakeEntry'; }
+        public function getStatus(): string { return 'enabled'; }
+    };
+
+    $result = $h->normalize($field, [$fakeEl], $element);
+    expect($result)->toBe([[
+        'id' => 42,
+        'title' => 'Hello',
+        'type' => 'FakeEntry',
+        'status' => 'enabled',
+    ]]);
+});
+
+it('RelationHandler clones ElementQuery-like objects and collects all()', function () {
+    $field = new Entries();
+    $element = new Entry();
+    $h = new RelationHandler();
+
+    $fakeEl = new class {
+        public int $id = 7;
+        public string $title = 'Q';
+        public static function displayName(): string { return 'Q'; }
+        public function getStatus(): string { return 'live'; }
+    };
+
+    $query = new class($fakeEl) {
+        public bool $statusCalled = false;
+        private array $items;
+        public function __construct($el) { $this->items = [$el]; }
+        public function status($s): self { $this->statusCalled = true; return $this; }
+        public function all(): array { return $this->items; }
+    };
+
+    $out = $h->normalize($field, $query, $element);
+    expect($out)->toBeArray();
+    expect($out[0]['id'])->toBe(7);
+    expect($out[0]['type'])->toBe('Q');
+});
+
+it('MoneyHandler normalizes amount+currency', function () {
+    $field = new Money();
+    $field->currency = 'EUR';
+    $element = new Entry();
+    $h = new MoneyHandler();
+
+    expect($h->normalize($field, null, $element))->toBeNull();
+
+    // Integer cents
+    expect($h->normalize($field, 1250, $element))->toBe([
+        'amount' => 1250,
+        'currency' => 'EUR',
+        'display' => '12.50 EUR',
+    ]);
+
+    // Object with getAmount()
+    $money = new class {
+        public function getAmount(): int { return 9999; }
+    };
+    expect($h->normalize($field, $money, $element))->toBe([
+        'amount' => 9999,
+        'currency' => 'EUR',
+        'display' => '99.99 EUR',
+    ]);
+});
+
+it('TableHandler maps handle-keyed rows to heading-keyed rows', function () {
+    $field = new Table();
+    $field->columns = [
+        'col1' => ['heading' => 'Name', 'handle' => 'col1', 'type' => 'singleline'],
+        'col2' => ['heading' => 'Age', 'handle' => 'col2', 'type' => 'number'],
+    ];
+    $element = new Entry();
+    $h = new TableHandler();
+
+    expect($h->normalize($field, null, $element))->toBe([]);
+    expect($h->normalize($field, 'not-array', $element))->toBe([]);
+
+    $rows = [
+        ['col1' => 'Alice', 'col2' => 30],
+        ['col1' => 'Bob', 'col2' => 25],
+    ];
+    expect($h->normalize($field, $rows, $element))->toBe([
+        ['Name' => 'Alice', 'Age' => 30],
+        ['Name' => 'Bob', 'Age' => 25],
+    ]);
+});
+
+it('MatrixHandler returns [] for non-query raw values', function () {
+    $field = new Matrix();
+    $element = new Entry();
+    $h = new MatrixHandler();
+
+    expect($h->normalize($field, null, $element))->toBe([]);
+    expect($h->normalize($field, 'nope', $element))->toBe([]);
+});
+
+// --- Registry integration -----------------------------------------------
+
+it('registry resolves PlainText → PlainHandler after plugin init', function () {
+    $registry = Audit::$plugin->fieldHandlerRegistry;
+    $registry->reset();
+
+    // Re-register the built-in handlers for this test run.
+    \yii\base\Event::on(
+        \superbig\audit\services\FieldHandlerRegistry::class,
+        \superbig\audit\services\FieldHandlerRegistry::EVENT_REGISTER_HANDLERS,
+        static function (\superbig\audit\events\RegisterFieldHandlersEvent $event) {
+            $event->handlers[] = PlainHandler::class;
+            $event->handlers[] = BooleanHandler::class;
+            $event->handlers[] = ColorHandler::class;
+        }
+    );
+
+    expect($registry->getHandler(new PlainText()))->toBeInstanceOf(PlainHandler::class);
+    expect($registry->getHandler(new Lightswitch()))->toBeInstanceOf(BooleanHandler::class);
+    expect($registry->getHandler(new Color()))->toBeInstanceOf(ColorHandler::class);
+    expect($registry->getTypeKey(new PlainText()))->toBe('plain');
+
+    \yii\base\Event::off(
+        \superbig\audit\services\FieldHandlerRegistry::class,
+        \superbig\audit\services\FieldHandlerRegistry::EVENT_REGISTER_HANDLERS
+    );
+    $registry->reset();
+});


### PR DESCRIPTION
Part of the v3 refactor stack for [FRE-56](https://linear.app/sanity/issue/FRE-56). Closes [FRE-126](https://linear.app/sanity/issue/fre-126).


**Diff:** 17 files changed, 1158 insertions(+)
**Tests:** 69 → 91 (+22)
**Verified on fresh DB:** `DROP DATABASE; pest` green

### Stack navigation

↑ Builds on **#91** `core-services-recorder` (P1.2)
↓ Followed by **#93** `project-config-tracking` (P1.4)

### Review notes

- Single-commit branch — review the commit, not just the diff
- BC preserved — old `AuditService` API still works via @deprecated delegators
- This is a **draft** — not a request to merge yet. Marked ready when the stack is approved end-to-end.

