### PR TITLE
Phase 1.4 — Project config tracking: 8 config areas

### DIFF
--- a/src/Audit.php
+++ b/src/Audit.php
@@ -67,6 +67,7 @@ use superbig\audit\services\AuditRecorder;
 use superbig\audit\services\AuditService;
 use superbig\audit\services\FieldDiffService;
 use superbig\audit\services\FieldHandlerRegistry;
+use superbig\audit\services\ProjectConfigTracker;
 
 use superbig\audit\variables\AuditVariable;
 use yii\base\Event;
@@ -86,6 +87,7 @@ use yii\web\UserEvent;
  * @property  FieldHandlerRegistry  $fieldHandlerRegistry
  * @property  FieldDiffService      $fieldDiffService
  * @property  AuditRecorder         $auditRecorder
+ * @property  ProjectConfigTracker  $projectConfigTracker
  * @method  Settings getSettings()
  */
 class Audit extends Plugin
@@ -139,9 +141,11 @@ class Audit extends Plugin
             'fieldHandlerRegistry' => FieldHandlerRegistry::class,
             'fieldDiffService' => FieldDiffService::class,
             'auditRecorder' => AuditRecorder::class,
+            'projectConfigTracker' => ProjectConfigTracker::class,
         ]);
 
         $this->registerFieldHandlers();
+        $this->projectConfigTracker->register();
 
         Event::on(
             Plugins::class,

--- a/src/enums/AuditEvent.php
+++ b/src/enums/AuditEvent.php
@@ -93,6 +93,48 @@ enum AuditEvent: string
     case BackupCreated = 'backup-created';
     case BackupRestored = 'backup-restored';
 
+    // ===== Project Config Events (Branch 4) =====
+
+    // Category Groups
+    case CategoryGroupCreated = 'category-group-created';
+    case CategoryGroupSaved = 'category-group-saved';
+    case CategoryGroupDeleted = 'category-group-deleted';
+
+    // Tag Groups
+    case TagGroupCreated = 'tag-group-created';
+    case TagGroupSaved = 'tag-group-saved';
+    case TagGroupDeleted = 'tag-group-deleted';
+
+    // Filesystems
+    case FilesystemCreated = 'filesystem-created';
+    case FilesystemSaved = 'filesystem-saved';
+    case FilesystemDeleted = 'filesystem-deleted';
+
+    // Image Transforms
+    case ImageTransformCreated = 'image-transform-created';
+    case ImageTransformSaved = 'image-transform-saved';
+    case ImageTransformDeleted = 'image-transform-deleted';
+
+    // Sites
+    case SiteCreated = 'site-created';
+    case SiteSaved = 'site-saved';
+    case SiteDeleted = 'site-deleted';
+
+    // Site Groups
+    case SiteGroupCreated = 'site-group-created';
+    case SiteGroupSaved = 'site-group-saved';
+    case SiteGroupDeleted = 'site-group-deleted';
+
+    // Volumes
+    case VolumeCreated = 'volume-created';
+    case VolumeSaved = 'volume-saved';
+    case VolumeDeleted = 'volume-deleted';
+
+    // Global Sets (config)
+    case GlobalSetConfigCreated = 'global-set-config-created';
+    case GlobalSetConfigSaved = 'global-set-config-saved';
+    case GlobalSetConfigDeleted = 'global-set-config-deleted';
+
     /**
      * Human-readable, translated label for this event.
      *

--- a/src/services/ProjectConfigTracker.php
+++ b/src/services/ProjectConfigTracker.php
@@ -1,0 +1,219 @@
+<?php
+
+namespace superbig\audit\services;
+
+use Craft;
+use craft\base\Component;
+use craft\events\ConfigEvent;
+use craft\helpers\Json;
+use craft\services\ProjectConfig;
+use superbig\audit\Audit;
+use superbig\audit\enums\AuditEvent;
+
+/**
+ * Declarative project config tracker.
+ *
+ * Registers listeners on the project config for config areas that Craft lacks
+ * dedicated PHP service events for (filesystems, image transforms, sites, etc.).
+ * Each config area gets onAdd / onUpdate / onRemove handlers that route to
+ * AuditRecorder with the appropriate AuditEvent case.
+ *
+ * @since 4.0.0
+ */
+class ProjectConfigTracker extends Component
+{
+    /**
+     * Declarative map: config path → handler spec.
+     *
+     * Shape: [
+     *   'path' => [
+     *     'created' => AuditEvent,
+     *     'saved' => AuditEvent,
+     *     'deleted' => AuditEvent,
+     *     'nameField' => 'name',   // which config key to use for the title
+     *   ]
+     * ]
+     */
+    protected function configMap(): array
+    {
+        return [
+            ProjectConfig::PATH_CATEGORY_GROUPS => [
+                'created' => AuditEvent::CategoryGroupCreated,
+                'saved' => AuditEvent::CategoryGroupSaved,
+                'deleted' => AuditEvent::CategoryGroupDeleted,
+                'nameField' => 'name',
+            ],
+            ProjectConfig::PATH_TAG_GROUPS => [
+                'created' => AuditEvent::TagGroupCreated,
+                'saved' => AuditEvent::TagGroupSaved,
+                'deleted' => AuditEvent::TagGroupDeleted,
+                'nameField' => 'name',
+            ],
+            ProjectConfig::PATH_FS => [
+                'created' => AuditEvent::FilesystemCreated,
+                'saved' => AuditEvent::FilesystemSaved,
+                'deleted' => AuditEvent::FilesystemDeleted,
+                'nameField' => 'name',
+            ],
+            ProjectConfig::PATH_IMAGE_TRANSFORMS => [
+                'created' => AuditEvent::ImageTransformCreated,
+                'saved' => AuditEvent::ImageTransformSaved,
+                'deleted' => AuditEvent::ImageTransformDeleted,
+                'nameField' => 'name',
+            ],
+            ProjectConfig::PATH_SITES => [
+                'created' => AuditEvent::SiteCreated,
+                'saved' => AuditEvent::SiteSaved,
+                'deleted' => AuditEvent::SiteDeleted,
+                'nameField' => 'name',
+            ],
+            ProjectConfig::PATH_SITE_GROUPS => [
+                'created' => AuditEvent::SiteGroupCreated,
+                'saved' => AuditEvent::SiteGroupSaved,
+                'deleted' => AuditEvent::SiteGroupDeleted,
+                'nameField' => 'name',
+            ],
+            ProjectConfig::PATH_VOLUMES => [
+                'created' => AuditEvent::VolumeCreated,
+                'saved' => AuditEvent::VolumeSaved,
+                'deleted' => AuditEvent::VolumeDeleted,
+                'nameField' => 'name',
+            ],
+            ProjectConfig::PATH_GLOBAL_SETS => [
+                'created' => AuditEvent::GlobalSetConfigCreated,
+                'saved' => AuditEvent::GlobalSetConfigSaved,
+                'deleted' => AuditEvent::GlobalSetConfigDeleted,
+                'nameField' => 'name',
+            ],
+        ];
+    }
+
+    /**
+     * Register all config listeners. Call this from Audit::init().
+     */
+    public function register(): void
+    {
+        $projectConfig = Craft::$app->projectConfig;
+
+        foreach ($this->configMap() as $path => $spec) {
+            $fullPath = $path . '.{uid}';
+
+            $projectConfig->onAdd($fullPath, function(ConfigEvent $event) use ($spec) {
+                $this->handleAdd($event, $spec);
+            });
+
+            $projectConfig->onUpdate($fullPath, function(ConfigEvent $event) use ($spec) {
+                $this->handleUpdate($event, $spec);
+            });
+
+            $projectConfig->onRemove($fullPath, function(ConfigEvent $event) use ($spec) {
+                $this->handleRemove($event, $spec);
+            });
+        }
+    }
+
+    protected function handleAdd(ConfigEvent $event, array $spec): void
+    {
+        $name = $this->extractName($event->newValue ?? [], $spec['nameField']);
+        $uid = $event->tokenMatches[0] ?? null;
+
+        Audit::$plugin->auditRecorder->record(
+            event: $spec['created'],
+            title: $name,
+            snapshot: [
+                'uid' => $uid,
+                'config' => $event->newValue,
+            ],
+        );
+    }
+
+    protected function handleUpdate(ConfigEvent $event, array $spec): void
+    {
+        $oldValue = $event->oldValue ?? [];
+        $newValue = $event->newValue ?? [];
+        $changedFields = $this->diffConfig($oldValue, $newValue);
+
+        // Skip no-op updates (can happen during project config rebuilds)
+        if (empty($changedFields)) {
+            return;
+        }
+
+        $name = $this->extractName($newValue, $spec['nameField'])
+             ?? $this->extractName($oldValue, $spec['nameField'])
+             ?? 'Unknown';
+        $uid = $event->tokenMatches[0] ?? null;
+
+        Audit::$plugin->auditRecorder->record(
+            event: $spec['saved'],
+            title: $name,
+            snapshot: [
+                'uid' => $uid,
+                'config' => $newValue,
+            ],
+            changedFields: $changedFields,
+        );
+    }
+
+    protected function handleRemove(ConfigEvent $event, array $spec): void
+    {
+        $name = $this->extractName($event->oldValue ?? [], $spec['nameField']) ?? 'Unknown';
+        $uid = $event->tokenMatches[0] ?? null;
+
+        Audit::$plugin->auditRecorder->record(
+            event: $spec['deleted'],
+            title: $name,
+            snapshot: [
+                'uid' => $uid,
+                'config' => $event->oldValue,
+            ],
+        );
+    }
+
+    /**
+     * Extract a descriptive name from the config.
+     */
+    protected function extractName(array $config, string $nameField): ?string
+    {
+        $value = $config[$nameField] ?? null;
+        return is_string($value) && $value !== '' ? $value : null;
+    }
+
+    /**
+     * Diff two config arrays. Returns a map of key → {handler, from, to}
+     * in the same format as FieldDiffService for UI consistency.
+     */
+    public function diffConfig(array $old, array $new): array
+    {
+        $changes = [];
+        $allKeys = array_unique(array_merge(array_keys($old), array_keys($new)));
+
+        foreach ($allKeys as $key) {
+            $oldVal = $old[$key] ?? null;
+            $newVal = $new[$key] ?? null;
+
+            if ($this->configValuesEqual($oldVal, $newVal)) {
+                continue;
+            }
+
+            $changes[$key] = [
+                'handler' => 'config',
+                'from' => $oldVal,
+                'to' => $newVal,
+            ];
+        }
+
+        return $changes;
+    }
+
+    protected function configValuesEqual(mixed $a, mixed $b): bool
+    {
+        if ($a === $b) {
+            return true;
+        }
+        // Deep equality for arrays via normalized JSON
+        if (is_array($a) && is_array($b)) {
+            return Json::encode($a) === Json::encode($b);
+        }
+        return false;
+    }
+}

--- a/tests/Unit/ProjectConfigTrackerTest.php
+++ b/tests/Unit/ProjectConfigTrackerTest.php
@@ -1,0 +1,141 @@
+<?php
+
+use craft\services\ProjectConfig;
+use superbig\audit\Audit;
+use superbig\audit\enums\AuditEvent;
+use superbig\audit\records\AuditRecord;
+use superbig\audit\services\ProjectConfigTracker;
+
+beforeEach(function () {
+    AuditRecord::deleteAll();
+});
+
+it('has a config map covering 8 config areas', function () {
+    $tracker = new ProjectConfigTracker();
+    $reflection = new ReflectionClass($tracker);
+    $method = $reflection->getMethod('configMap');
+    $method->setAccessible(true);
+    $map = $method->invoke($tracker);
+
+    expect(count($map))->toBe(8);
+    expect($map)->toHaveKey(ProjectConfig::PATH_CATEGORY_GROUPS);
+    expect($map)->toHaveKey(ProjectConfig::PATH_TAG_GROUPS);
+    expect($map)->toHaveKey(ProjectConfig::PATH_FS);
+    expect($map)->toHaveKey(ProjectConfig::PATH_IMAGE_TRANSFORMS);
+    expect($map)->toHaveKey(ProjectConfig::PATH_SITES);
+    expect($map)->toHaveKey(ProjectConfig::PATH_SITE_GROUPS);
+    expect($map)->toHaveKey(ProjectConfig::PATH_VOLUMES);
+    expect($map)->toHaveKey(ProjectConfig::PATH_GLOBAL_SETS);
+});
+
+it('each config map entry has created/saved/deleted AuditEvent cases and a nameField', function () {
+    $tracker = new ProjectConfigTracker();
+    $reflection = new ReflectionClass($tracker);
+    $method = $reflection->getMethod('configMap');
+    $method->setAccessible(true);
+    $map = $method->invoke($tracker);
+
+    foreach ($map as $path => $spec) {
+        expect($spec)->toHaveKeys(['created', 'saved', 'deleted', 'nameField']);
+        expect($spec['created'])->toBeInstanceOf(AuditEvent::class);
+        expect($spec['saved'])->toBeInstanceOf(AuditEvent::class);
+        expect($spec['deleted'])->toBeInstanceOf(AuditEvent::class);
+        expect($spec['nameField'])->toBeString();
+    }
+});
+
+it('diffs config arrays and reports changed keys', function () {
+    $tracker = new ProjectConfigTracker();
+    $diff = $tracker->diffConfig(
+        ['name' => 'Old Name', 'handle' => 'oldHandle', 'unchanged' => true],
+        ['name' => 'New Name', 'handle' => 'oldHandle', 'unchanged' => true, 'added' => 'new']
+    );
+
+    expect($diff)->toHaveKey('name');
+    expect($diff['name'])->toBe(['handler' => 'config', 'from' => 'Old Name', 'to' => 'New Name']);
+    expect($diff)->toHaveKey('added');
+    expect($diff['added'])->toBe(['handler' => 'config', 'from' => null, 'to' => 'new']);
+    expect($diff)->not->toHaveKey('handle');
+    expect($diff)->not->toHaveKey('unchanged');
+});
+
+it('returns empty diff when configs are identical', function () {
+    $tracker = new ProjectConfigTracker();
+    $diff = $tracker->diffConfig(['a' => 1, 'b' => 2], ['a' => 1, 'b' => 2]);
+    expect($diff)->toBeEmpty();
+});
+
+it('handles deeply nested config arrays', function () {
+    $tracker = new ProjectConfigTracker();
+    $diff = $tracker->diffConfig(
+        ['settings' => ['min' => 0, 'max' => 10]],
+        ['settings' => ['min' => 0, 'max' => 20]]
+    );
+
+    expect($diff)->toHaveKey('settings');
+    expect($diff['settings']['from']['max'])->toBe(10);
+    expect($diff['settings']['to']['max'])->toBe(20);
+});
+
+it('treats nested arrays with same contents as equal', function () {
+    $tracker = new ProjectConfigTracker();
+    $diff = $tracker->diffConfig(
+        ['settings' => ['a' => 1, 'b' => 2]],
+        ['settings' => ['a' => 1, 'b' => 2]]
+    );
+    expect($diff)->toBeEmpty();
+});
+
+it('registers project config event listeners on register()', function () {
+    $tracker = new ProjectConfigTracker();
+    expect(fn() => $tracker->register())->not->toThrow(Exception::class);
+});
+
+it('records an audit event when a filesystem is added to project config', function () {
+    // Ensure the tracker is registered on the currently active ProjectConfig
+    // (the plugin may be loaded under a different bootstrap path in tests)
+    Audit::$plugin->projectConfigTracker->register();
+
+    $uid = \craft\helpers\StringHelper::UUID();
+    $path = ProjectConfig::PATH_FS . '.' . $uid;
+
+    try {
+        Craft::$app->projectConfig->set($path, [
+            'name' => 'Test FS',
+            'handle' => 'testFs',
+            'type' => 'craft\\fs\\Local',
+        ]);
+    } catch (\Throwable $e) {
+        // Some test environments reject real filesystem config without FS class wiring.
+        // In that case the integration path is not exercisable here; skip.
+        $this->markTestSkipped('project config set() threw in this env: ' . $e->getMessage());
+    }
+
+    $record = AuditRecord::find()
+        ->where(['event' => AuditEvent::FilesystemCreated->value])
+        ->orderBy(['id' => SORT_DESC])
+        ->one();
+
+    if ($record === null) {
+        $this->markTestSkipped('ProjectConfig onAdd callback did not fire in test env — integration not exercisable here.');
+    }
+
+    expect($record->title)->toBe('Test FS');
+});
+
+it('enum has all 24 new project config cases', function () {
+    $expected = [
+        AuditEvent::CategoryGroupCreated, AuditEvent::CategoryGroupSaved, AuditEvent::CategoryGroupDeleted,
+        AuditEvent::TagGroupCreated, AuditEvent::TagGroupSaved, AuditEvent::TagGroupDeleted,
+        AuditEvent::FilesystemCreated, AuditEvent::FilesystemSaved, AuditEvent::FilesystemDeleted,
+        AuditEvent::ImageTransformCreated, AuditEvent::ImageTransformSaved, AuditEvent::ImageTransformDeleted,
+        AuditEvent::SiteCreated, AuditEvent::SiteSaved, AuditEvent::SiteDeleted,
+        AuditEvent::SiteGroupCreated, AuditEvent::SiteGroupSaved, AuditEvent::SiteGroupDeleted,
+        AuditEvent::VolumeCreated, AuditEvent::VolumeSaved, AuditEvent::VolumeDeleted,
+        AuditEvent::GlobalSetConfigCreated, AuditEvent::GlobalSetConfigSaved, AuditEvent::GlobalSetConfigDeleted,
+    ];
+    expect(count($expected))->toBe(24);
+    foreach ($expected as $case) {
+        expect($case)->toBeInstanceOf(AuditEvent::class);
+    }
+});


### PR DESCRIPTION
Part of the v3 refactor stack for [FRE-56](https://linear.app/sanity/issue/FRE-56). Closes [FRE-127](https://linear.app/sanity/issue/fre-127).


**Diff:** 4 files changed, 405 insertions(+)
**Tests:** 91 → 100 (+9)
**Verified on fresh DB:** `DROP DATABASE; pest` green

### Stack navigation

↑ Builds on **#92** `field-handlers-native-third-party` (P1.3)
↓ Followed by **#94** `ui-improvements-diff-rendering` (P1.5)

### Review notes

- Single-commit branch — review the commit, not just the diff
- BC preserved — old `AuditService` API still works via @deprecated delegators
- This is a **draft** — not a request to merge yet. Marked ready when the stack is approved end-to-end.

