### PR TITLE
Phase 2.2 — Decompose AuditService: Schema/Route/Backup/Plugin/Settings handlers

### DIFF
--- a/src/Audit.php
+++ b/src/Audit.php
@@ -68,7 +68,12 @@ use superbig\audit\services\AuditService;
 use superbig\audit\services\DiffRenderer;
 use superbig\audit\services\FieldDiffService;
 use superbig\audit\services\FieldHandlerRegistry;
+use superbig\audit\services\handlers\BackupHandler;
 use superbig\audit\services\handlers\ElementHandler;
+use superbig\audit\services\handlers\PluginHandler;
+use superbig\audit\services\handlers\RouteHandler;
+use superbig\audit\services\handlers\SchemaHandler;
+use superbig\audit\services\handlers\SettingsHandler;
 use superbig\audit\services\handlers\UserGroupHandler;
 use superbig\audit\services\handlers\UserHandler;
 use superbig\audit\services\ProjectConfigTracker;
@@ -96,6 +101,11 @@ use yii\web\UserEvent;
  * @property  ElementHandler        $elementHandler
  * @property  UserHandler           $userHandler
  * @property  UserGroupHandler      $userGroupHandler
+ * @property  SchemaHandler         $schemaHandler
+ * @property  RouteHandler          $routeHandler
+ * @property  BackupHandler         $backupHandler
+ * @property  PluginHandler         $pluginHandler
+ * @property  SettingsHandler       $settingsHandler
  * @method  Settings getSettings()
  */
 class Audit extends Plugin
@@ -154,6 +164,11 @@ class Audit extends Plugin
             'elementHandler' => ElementHandler::class,
             'userHandler' => UserHandler::class,
             'userGroupHandler' => UserGroupHandler::class,
+            'schemaHandler' => SchemaHandler::class,
+            'routeHandler' => RouteHandler::class,
+            'backupHandler' => BackupHandler::class,
+            'pluginHandler' => PluginHandler::class,
+            'settingsHandler' => SettingsHandler::class,
         ]);
 
         $this->registerFieldHandlers();

--- a/src/services/AuditService.php
+++ b/src/services/AuditService.php
@@ -35,7 +35,6 @@ use craft\queue\jobs\ResaveElements;
 use DateTime;
 use superbig\audit\Audit;
 use superbig\audit\events\SnapshotEvent;
-use superbig\audit\helpers\Route;
 use superbig\audit\models\AuditModel;
 use superbig\audit\records\AuditRecord;
 use yii\base\Exception;
@@ -177,33 +176,12 @@ class AuditService extends Component
      *
      * @return bool
      */
+    /**
+     * @deprecated Use Audit::$plugin->pluginHandler->onPluginEvent() instead
+     */
     public function onPluginEvent(string $event, PluginInterface $plugin): bool
     {
-        if (!Audit::$plugin->getSettings()->logPluginEvents) {
-            return false;
-        }
-
-        /** @var Plugin $plugin */
-        try {
-            $model = $this->_getStandardModel();
-            $model->event = $event;
-            $model->title = $plugin->name;
-            $snapshot = [
-                'title' => $plugin->name,
-                'handle' => $plugin->handle,
-                'version' => $plugin->version,
-            ];
-            $model->snapshot = $snapshot;
-
-            return $this->_saveRecord($model);
-        } catch (\Exception $e) {
-            Craft::error(
-                Craft::t('audit', 'Error when logging: {error}', ['error' => $e->getMessage()]),
-                __METHOD__
-            );
-
-            return false;
-        }
+        return Audit::$plugin->pluginHandler->onPluginEvent($event, $plugin);
     }
 
     /**
@@ -384,49 +362,20 @@ class AuditService extends Component
         return Audit::$plugin->elementHandler->getParentIdKey($elementType);
     }
 
+    /**
+     * @deprecated Use Audit::$plugin->routeHandler->onSaveRoute() instead
+     */
     public function onSaveRoute(RouteEvent $event)
     {
-        if (!Audit::$plugin->getSettings()->logRouteEvents) {
-            return false;
-        }
-
-        $this->catchSaveError(function() use ($event) {
-            $uriDisplay = Route::getUriDisplayHtml($event->uriParts);
-            $model = $this->_getStandardModel();
-            // Craft 5's RouteEvent doesn't expose routeId, so we can't distinguish new vs. existing
-            $model->event = AuditModel::EVENT_SAVED_ROUTE;
-            $model->title = $uriDisplay . ' -> ' . $event->template;
-            $snapshot = [
-                'uriParts' => $event->uriParts,
-                'template' => $event->template,
-                'siteUid' => $event->siteUid,
-            ];
-            $model->snapshot = $this->afterSnapshot($model, array_merge($model->snapshot, $snapshot));
-
-            return $this->_saveRecord($model);
-        });
+        return Audit::$plugin->routeHandler->onSaveRoute($event);
     }
 
+    /**
+     * @deprecated Use Audit::$plugin->routeHandler->onDeleteRoute() instead
+     */
     public function onDeleteRoute(RouteEvent $event)
     {
-        if (!Audit::$plugin->getSettings()->logRouteEvents) {
-            return false;
-        }
-
-        $this->catchSaveError(function() use ($event) {
-            $uriDisplay = Route::getUriDisplayHtml($event->uriParts);
-            $model = $this->_getStandardModel();
-            $model->event = AuditModel::EVENT_DELETED_ROUTE;
-            $model->title = $uriDisplay . ' -> ' . $event->template;
-            $snapshot = [
-                'uriParts' => $event->uriParts,
-                'template' => $event->template,
-                'siteUid' => $event->siteUid,
-            ];
-            $model->snapshot = $this->afterSnapshot($model, array_merge($model->snapshot, $snapshot));
-
-            return $this->_saveRecord($model);
-        });
+        return Audit::$plugin->routeHandler->onDeleteRoute($event);
     }
 
     /**
@@ -551,202 +500,79 @@ class AuditService extends Component
     // Schema Events
     // =========================================================================
 
+    /**
+     * @deprecated Use Audit::$plugin->schemaHandler->onFieldSaved() instead
+     */
     public function onFieldSaved(FieldEvent $event): bool
     {
-        if (!Audit::$plugin->getSettings()->logSchemaEvents) {
-            return false;
-        }
-
-        return $this->catchSaveError(function() use ($event) {
-            $field = $event->field;
-            $isNew = $event->isNew;
-
-            $model = $this->_getStandardModel();
-            $model->event = $isNew ? AuditModel::EVENT_FIELD_CREATED : AuditModel::EVENT_FIELD_SAVED;
-            $model->title = $field->name;
-            $model->snapshot = $this->afterSnapshot($model, array_merge($model->snapshot, [
-                'fieldId' => $field->id,
-                'fieldName' => $field->name,
-                'fieldHandle' => $field->handle,
-                'fieldType' => get_class($field),
-            ]));
-
-            return $this->_saveRecord($model);
-        });
+        return Audit::$plugin->schemaHandler->onFieldSaved($event);
     }
 
+    /**
+     * @deprecated Use Audit::$plugin->schemaHandler->onFieldDeleted() instead
+     */
     public function onFieldDeleted(FieldEvent $event): bool
     {
-        if (!Audit::$plugin->getSettings()->logSchemaEvents) {
-            return false;
-        }
-
-        return $this->catchSaveError(function() use ($event) {
-            $field = $event->field;
-
-            $model = $this->_getStandardModel();
-            $model->event = AuditModel::EVENT_FIELD_DELETED;
-            $model->title = $field->name;
-            $model->snapshot = $this->afterSnapshot($model, array_merge($model->snapshot, [
-                'fieldId' => $field->id,
-                'fieldName' => $field->name,
-                'fieldHandle' => $field->handle,
-                'fieldType' => get_class($field),
-            ]));
-
-            return $this->_saveRecord($model);
-        });
+        return Audit::$plugin->schemaHandler->onFieldDeleted($event);
     }
 
+    /**
+     * @deprecated Use Audit::$plugin->schemaHandler->onSectionSaved() instead
+     */
     public function onSectionSaved(SectionEvent $event): bool
     {
-        if (!Audit::$plugin->getSettings()->logSchemaEvents) {
-            return false;
-        }
-
-        return $this->catchSaveError(function() use ($event) {
-            $section = $event->section;
-            $isNew = $event->isNew;
-
-            $model = $this->_getStandardModel();
-            $model->event = $isNew ? AuditModel::EVENT_SECTION_CREATED : AuditModel::EVENT_SECTION_SAVED;
-            $model->title = $section->name;
-            $model->snapshot = $this->afterSnapshot($model, array_merge($model->snapshot, [
-                'sectionId' => $section->id,
-                'sectionName' => $section->name,
-                'sectionHandle' => $section->handle,
-                'sectionType' => $section->type,
-            ]));
-
-            return $this->_saveRecord($model);
-        });
+        return Audit::$plugin->schemaHandler->onSectionSaved($event);
     }
 
+    /**
+     * @deprecated Use Audit::$plugin->schemaHandler->onSectionDeleted() instead
+     */
     public function onSectionDeleted(SectionEvent $event): bool
     {
-        if (!Audit::$plugin->getSettings()->logSchemaEvents) {
-            return false;
-        }
-
-        return $this->catchSaveError(function() use ($event) {
-            $section = $event->section;
-
-            $model = $this->_getStandardModel();
-            $model->event = AuditModel::EVENT_SECTION_DELETED;
-            $model->title = $section->name;
-            $model->snapshot = $this->afterSnapshot($model, array_merge($model->snapshot, [
-                'sectionId' => $section->id,
-                'sectionName' => $section->name,
-                'sectionHandle' => $section->handle,
-                'sectionType' => $section->type,
-            ]));
-
-            return $this->_saveRecord($model);
-        });
+        return Audit::$plugin->schemaHandler->onSectionDeleted($event);
     }
 
+    /**
+     * @deprecated Use Audit::$plugin->schemaHandler->onEntryTypeSaved() instead
+     */
     public function onEntryTypeSaved(EntryTypeEvent $event): bool
     {
-        if (!Audit::$plugin->getSettings()->logSchemaEvents) {
-            return false;
-        }
-
-        return $this->catchSaveError(function() use ($event) {
-            $entryType = $event->entryType;
-            $isNew = $event->isNew;
-
-            $model = $this->_getStandardModel();
-            $model->event = $isNew ? AuditModel::EVENT_ENTRY_TYPE_CREATED : AuditModel::EVENT_ENTRY_TYPE_SAVED;
-            $model->title = $entryType->name;
-            $model->snapshot = $this->afterSnapshot($model, array_merge($model->snapshot, [
-                'entryTypeId' => $entryType->id,
-                'entryTypeName' => $entryType->name,
-                'entryTypeHandle' => $entryType->handle,
-            ]));
-
-            return $this->_saveRecord($model);
-        });
+        return Audit::$plugin->schemaHandler->onEntryTypeSaved($event);
     }
 
+    /**
+     * @deprecated Use Audit::$plugin->schemaHandler->onEntryTypeDeleted() instead
+     */
     public function onEntryTypeDeleted(EntryTypeEvent $event): bool
     {
-        if (!Audit::$plugin->getSettings()->logSchemaEvents) {
-            return false;
-        }
-
-        return $this->catchSaveError(function() use ($event) {
-            $entryType = $event->entryType;
-
-            $model = $this->_getStandardModel();
-            $model->event = AuditModel::EVENT_ENTRY_TYPE_DELETED;
-            $model->title = $entryType->name;
-            $model->snapshot = $this->afterSnapshot($model, array_merge($model->snapshot, [
-                'entryTypeId' => $entryType->id,
-                'entryTypeName' => $entryType->name,
-                'entryTypeHandle' => $entryType->handle,
-            ]));
-
-            return $this->_saveRecord($model);
-        });
+        return Audit::$plugin->schemaHandler->onEntryTypeDeleted($event);
     }
 
     // =========================================================================
     // Database Events
     // =========================================================================
 
+    /**
+     * @deprecated Use Audit::$plugin->backupHandler->onBackupCreated() instead
+     */
     public function onBackupCreated(BackupEvent $event): bool
     {
-        if (!Audit::$plugin->getSettings()->logDatabaseEvents) {
-            return false;
-        }
-
-        return $this->catchSaveError(function() use ($event) {
-            $model = $this->_getStandardModel();
-            $model->event = AuditModel::EVENT_BACKUP_CREATED;
-            $model->title = basename($event->file);
-            $model->snapshot = $this->afterSnapshot($model, array_merge($model->snapshot, [
-                'file' => $event->file,
-                'ignoreTables' => $event->ignoreTables,
-            ]));
-
-            return $this->_saveRecord($model);
-        });
+        return Audit::$plugin->backupHandler->onBackupCreated($event);
     }
 
+    /**
+     * @deprecated Use Audit::$plugin->backupHandler->onBackupRestored() instead
+     */
     public function onBackupRestored(RestoreEvent $event): bool
     {
-        if (!Audit::$plugin->getSettings()->logDatabaseEvents) {
-            return false;
-        }
-
-        return $this->catchSaveError(function() use ($event) {
-            $model = $this->_getStandardModel();
-            $model->event = AuditModel::EVENT_BACKUP_RESTORED;
-            $model->title = basename($event->file);
-            $model->snapshot = $this->afterSnapshot($model, array_merge($model->snapshot, [
-                'file' => $event->file,
-            ]));
-
-            return $this->_saveRecord($model);
-        });
+        return Audit::$plugin->backupHandler->onBackupRestored($event);
     }
 
+    /**
+     * @deprecated Use Audit::$plugin->settingsHandler->onSettingsChanged() instead
+     */
     public function onSettingsChanged(ConfigEvent $event, string $settingsType): bool
     {
-        return $this->catchSaveError(function() use ($event, $settingsType) {
-            $model = $this->_getStandardModel();
-            $model->event = $settingsType === 'system'
-                ? AuditModel::EVENT_SYSTEM_SETTINGS_CHANGED
-                : AuditModel::EVENT_EMAIL_SETTINGS_CHANGED;
-            $model->title = ucfirst($settingsType) . ' settings';
-            $model->snapshot = $this->afterSnapshot($model, array_merge($model->snapshot, [
-                'settingsType' => $settingsType,
-                'path' => $event->path,
-                'oldValue' => $event->oldValue,
-                'newValue' => $event->newValue,
-            ]));
-
-            return $this->_saveRecord($model);
-        });
+        return Audit::$plugin->settingsHandler->onSettingsChanged($event, $settingsType);
     }
 }

--- a/src/services/handlers/BackupHandler.php
+++ b/src/services/handlers/BackupHandler.php
@@ -1,0 +1,70 @@
+<?php
+/**
+ * Audit plugin for Craft CMS 3.x
+ *
+ * @link      https://superbig.co
+ * @copyright Copyright (c) 2017 Superbig
+ */
+
+namespace superbig\audit\services\handlers;
+
+use craft\base\Component;
+use craft\events\BackupEvent;
+use craft\events\RestoreEvent;
+use superbig\audit\Audit;
+use superbig\audit\models\AuditModel;
+
+/**
+ * BackupHandler — handles database backup/restore audit events extracted from AuditService.
+ *
+ * Behavior is preserved verbatim: methods delegate back to AuditService for
+ * `_saveRecord`, `_getStandardModel`, `afterSnapshot`, and `catchSaveError`
+ * via `Audit::$plugin->auditService`.
+ *
+ * @author    Superbig
+ * @package   Audit
+ * @since     3.x
+ */
+class BackupHandler extends Component
+{
+    public function onBackupCreated(BackupEvent $event): bool
+    {
+        if (!Audit::$plugin->getSettings()->logDatabaseEvents) {
+            return false;
+        }
+
+        $auditService = Audit::$plugin->auditService;
+
+        return $auditService->catchSaveError(function() use ($event, $auditService) {
+            $model = $auditService->_getStandardModel();
+            $model->event = AuditModel::EVENT_BACKUP_CREATED;
+            $model->title = basename($event->file);
+            $model->snapshot = $auditService->afterSnapshot($model, array_merge($model->snapshot, [
+                'file' => $event->file,
+                'ignoreTables' => $event->ignoreTables,
+            ]));
+
+            return $auditService->_saveRecord($model);
+        });
+    }
+
+    public function onBackupRestored(RestoreEvent $event): bool
+    {
+        if (!Audit::$plugin->getSettings()->logDatabaseEvents) {
+            return false;
+        }
+
+        $auditService = Audit::$plugin->auditService;
+
+        return $auditService->catchSaveError(function() use ($event, $auditService) {
+            $model = $auditService->_getStandardModel();
+            $model->event = AuditModel::EVENT_BACKUP_RESTORED;
+            $model->title = basename($event->file);
+            $model->snapshot = $auditService->afterSnapshot($model, array_merge($model->snapshot, [
+                'file' => $event->file,
+            ]));
+
+            return $auditService->_saveRecord($model);
+        });
+    }
+}

--- a/src/services/handlers/PluginHandler.php
+++ b/src/services/handlers/PluginHandler.php
@@ -1,0 +1,59 @@
+<?php
+/**
+ * Audit plugin for Craft CMS 3.x
+ *
+ * @link      https://superbig.co
+ * @copyright Copyright (c) 2017 Superbig
+ */
+
+namespace superbig\audit\services\handlers;
+
+use Craft;
+use craft\base\Component;
+use craft\base\Plugin;
+use craft\base\PluginInterface;
+use superbig\audit\Audit;
+
+/**
+ * PluginHandler — handles plugin install/uninstall/enable/disable audit events extracted from AuditService.
+ *
+ * Behavior is preserved verbatim: methods delegate back to AuditService for
+ * `_saveRecord` and `_getStandardModel` via `Audit::$plugin->auditService`.
+ *
+ * @author    Superbig
+ * @package   Audit
+ * @since     3.x
+ */
+class PluginHandler extends Component
+{
+    public function onPluginEvent(string $event, PluginInterface $plugin): bool
+    {
+        if (!Audit::$plugin->getSettings()->logPluginEvents) {
+            return false;
+        }
+
+        $auditService = Audit::$plugin->auditService;
+
+        /** @var Plugin $plugin */
+        try {
+            $model = $auditService->_getStandardModel();
+            $model->event = $event;
+            $model->title = $plugin->name;
+            $snapshot = [
+                'title' => $plugin->name,
+                'handle' => $plugin->handle,
+                'version' => $plugin->version,
+            ];
+            $model->snapshot = $snapshot;
+
+            return $auditService->_saveRecord($model);
+        } catch (\Exception $e) {
+            Craft::error(
+                Craft::t('audit', 'Error when logging: {error}', ['error' => $e->getMessage()]),
+                __METHOD__
+            );
+
+            return false;
+        }
+    }
+}

--- a/src/services/handlers/RouteHandler.php
+++ b/src/services/handlers/RouteHandler.php
@@ -1,0 +1,78 @@
+<?php
+/**
+ * Audit plugin for Craft CMS 3.x
+ *
+ * @link      https://superbig.co
+ * @copyright Copyright (c) 2017 Superbig
+ */
+
+namespace superbig\audit\services\handlers;
+
+use craft\base\Component;
+use craft\events\RouteEvent;
+use superbig\audit\Audit;
+use superbig\audit\helpers\Route;
+use superbig\audit\models\AuditModel;
+
+/**
+ * RouteHandler — handles route save/delete audit events extracted from AuditService.
+ *
+ * Behavior is preserved verbatim: methods delegate back to AuditService for
+ * `_saveRecord`, `_getStandardModel`, `afterSnapshot`, and `catchSaveError`
+ * via `Audit::$plugin->auditService`.
+ *
+ * @author    Superbig
+ * @package   Audit
+ * @since     3.x
+ */
+class RouteHandler extends Component
+{
+    public function onSaveRoute(RouteEvent $event)
+    {
+        if (!Audit::$plugin->getSettings()->logRouteEvents) {
+            return false;
+        }
+
+        $auditService = Audit::$plugin->auditService;
+
+        $auditService->catchSaveError(function() use ($event, $auditService) {
+            $uriDisplay = Route::getUriDisplayHtml($event->uriParts);
+            $model = $auditService->_getStandardModel();
+            // Craft 5's RouteEvent doesn't expose routeId, so we can't distinguish new vs. existing
+            $model->event = AuditModel::EVENT_SAVED_ROUTE;
+            $model->title = $uriDisplay . ' -> ' . $event->template;
+            $snapshot = [
+                'uriParts' => $event->uriParts,
+                'template' => $event->template,
+                'siteUid' => $event->siteUid,
+            ];
+            $model->snapshot = $auditService->afterSnapshot($model, array_merge($model->snapshot, $snapshot));
+
+            return $auditService->_saveRecord($model);
+        });
+    }
+
+    public function onDeleteRoute(RouteEvent $event)
+    {
+        if (!Audit::$plugin->getSettings()->logRouteEvents) {
+            return false;
+        }
+
+        $auditService = Audit::$plugin->auditService;
+
+        $auditService->catchSaveError(function() use ($event, $auditService) {
+            $uriDisplay = Route::getUriDisplayHtml($event->uriParts);
+            $model = $auditService->_getStandardModel();
+            $model->event = AuditModel::EVENT_DELETED_ROUTE;
+            $model->title = $uriDisplay . ' -> ' . $event->template;
+            $snapshot = [
+                'uriParts' => $event->uriParts,
+                'template' => $event->template,
+                'siteUid' => $event->siteUid,
+            ];
+            $model->snapshot = $auditService->afterSnapshot($model, array_merge($model->snapshot, $snapshot));
+
+            return $auditService->_saveRecord($model);
+        });
+    }
+}

--- a/src/services/handlers/SchemaHandler.php
+++ b/src/services/handlers/SchemaHandler.php
@@ -1,0 +1,181 @@
+<?php
+/**
+ * Audit plugin for Craft CMS 3.x
+ *
+ * @link      https://superbig.co
+ * @copyright Copyright (c) 2017 Superbig
+ */
+
+namespace superbig\audit\services\handlers;
+
+use craft\base\Component;
+use craft\events\EntryTypeEvent;
+use craft\events\FieldEvent;
+use craft\events\SectionEvent;
+use superbig\audit\Audit;
+use superbig\audit\models\AuditModel;
+
+/**
+ * SchemaHandler — handles field / section / entry-type audit events extracted from AuditService.
+ *
+ * Behavior is preserved verbatim: methods delegate back to AuditService for
+ * `_saveRecord`, `_getStandardModel`, `afterSnapshot`, and `catchSaveError`
+ * via `Audit::$plugin->auditService`.
+ *
+ * @author    Superbig
+ * @package   Audit
+ * @since     3.x
+ */
+class SchemaHandler extends Component
+{
+    public function onFieldSaved(FieldEvent $event): bool
+    {
+        if (!Audit::$plugin->getSettings()->logSchemaEvents) {
+            return false;
+        }
+
+        $auditService = Audit::$plugin->auditService;
+
+        return $auditService->catchSaveError(function() use ($event, $auditService) {
+            $field = $event->field;
+            $isNew = $event->isNew;
+
+            $model = $auditService->_getStandardModel();
+            $model->event = $isNew ? AuditModel::EVENT_FIELD_CREATED : AuditModel::EVENT_FIELD_SAVED;
+            $model->title = $field->name;
+            $model->snapshot = $auditService->afterSnapshot($model, array_merge($model->snapshot, [
+                'fieldId' => $field->id,
+                'fieldName' => $field->name,
+                'fieldHandle' => $field->handle,
+                'fieldType' => get_class($field),
+            ]));
+
+            return $auditService->_saveRecord($model);
+        });
+    }
+
+    public function onFieldDeleted(FieldEvent $event): bool
+    {
+        if (!Audit::$plugin->getSettings()->logSchemaEvents) {
+            return false;
+        }
+
+        $auditService = Audit::$plugin->auditService;
+
+        return $auditService->catchSaveError(function() use ($event, $auditService) {
+            $field = $event->field;
+
+            $model = $auditService->_getStandardModel();
+            $model->event = AuditModel::EVENT_FIELD_DELETED;
+            $model->title = $field->name;
+            $model->snapshot = $auditService->afterSnapshot($model, array_merge($model->snapshot, [
+                'fieldId' => $field->id,
+                'fieldName' => $field->name,
+                'fieldHandle' => $field->handle,
+                'fieldType' => get_class($field),
+            ]));
+
+            return $auditService->_saveRecord($model);
+        });
+    }
+
+    public function onSectionSaved(SectionEvent $event): bool
+    {
+        if (!Audit::$plugin->getSettings()->logSchemaEvents) {
+            return false;
+        }
+
+        $auditService = Audit::$plugin->auditService;
+
+        return $auditService->catchSaveError(function() use ($event, $auditService) {
+            $section = $event->section;
+            $isNew = $event->isNew;
+
+            $model = $auditService->_getStandardModel();
+            $model->event = $isNew ? AuditModel::EVENT_SECTION_CREATED : AuditModel::EVENT_SECTION_SAVED;
+            $model->title = $section->name;
+            $model->snapshot = $auditService->afterSnapshot($model, array_merge($model->snapshot, [
+                'sectionId' => $section->id,
+                'sectionName' => $section->name,
+                'sectionHandle' => $section->handle,
+                'sectionType' => $section->type,
+            ]));
+
+            return $auditService->_saveRecord($model);
+        });
+    }
+
+    public function onSectionDeleted(SectionEvent $event): bool
+    {
+        if (!Audit::$plugin->getSettings()->logSchemaEvents) {
+            return false;
+        }
+
+        $auditService = Audit::$plugin->auditService;
+
+        return $auditService->catchSaveError(function() use ($event, $auditService) {
+            $section = $event->section;
+
+            $model = $auditService->_getStandardModel();
+            $model->event = AuditModel::EVENT_SECTION_DELETED;
+            $model->title = $section->name;
+            $model->snapshot = $auditService->afterSnapshot($model, array_merge($model->snapshot, [
+                'sectionId' => $section->id,
+                'sectionName' => $section->name,
+                'sectionHandle' => $section->handle,
+                'sectionType' => $section->type,
+            ]));
+
+            return $auditService->_saveRecord($model);
+        });
+    }
+
+    public function onEntryTypeSaved(EntryTypeEvent $event): bool
+    {
+        if (!Audit::$plugin->getSettings()->logSchemaEvents) {
+            return false;
+        }
+
+        $auditService = Audit::$plugin->auditService;
+
+        return $auditService->catchSaveError(function() use ($event, $auditService) {
+            $entryType = $event->entryType;
+            $isNew = $event->isNew;
+
+            $model = $auditService->_getStandardModel();
+            $model->event = $isNew ? AuditModel::EVENT_ENTRY_TYPE_CREATED : AuditModel::EVENT_ENTRY_TYPE_SAVED;
+            $model->title = $entryType->name;
+            $model->snapshot = $auditService->afterSnapshot($model, array_merge($model->snapshot, [
+                'entryTypeId' => $entryType->id,
+                'entryTypeName' => $entryType->name,
+                'entryTypeHandle' => $entryType->handle,
+            ]));
+
+            return $auditService->_saveRecord($model);
+        });
+    }
+
+    public function onEntryTypeDeleted(EntryTypeEvent $event): bool
+    {
+        if (!Audit::$plugin->getSettings()->logSchemaEvents) {
+            return false;
+        }
+
+        $auditService = Audit::$plugin->auditService;
+
+        return $auditService->catchSaveError(function() use ($event, $auditService) {
+            $entryType = $event->entryType;
+
+            $model = $auditService->_getStandardModel();
+            $model->event = AuditModel::EVENT_ENTRY_TYPE_DELETED;
+            $model->title = $entryType->name;
+            $model->snapshot = $auditService->afterSnapshot($model, array_merge($model->snapshot, [
+                'entryTypeId' => $entryType->id,
+                'entryTypeName' => $entryType->name,
+                'entryTypeHandle' => $entryType->handle,
+            ]));
+
+            return $auditService->_saveRecord($model);
+        });
+    }
+}

--- a/src/services/handlers/SettingsHandler.php
+++ b/src/services/handlers/SettingsHandler.php
@@ -1,0 +1,49 @@
+<?php
+/**
+ * Audit plugin for Craft CMS 3.x
+ *
+ * @link      https://superbig.co
+ * @copyright Copyright (c) 2017 Superbig
+ */
+
+namespace superbig\audit\services\handlers;
+
+use craft\base\Component;
+use craft\events\ConfigEvent;
+use superbig\audit\Audit;
+use superbig\audit\models\AuditModel;
+
+/**
+ * SettingsHandler — handles system/email settings change audit events extracted from AuditService.
+ *
+ * Behavior is preserved verbatim: methods delegate back to AuditService for
+ * `_saveRecord`, `_getStandardModel`, `afterSnapshot`, and `catchSaveError`
+ * via `Audit::$plugin->auditService`.
+ *
+ * @author    Superbig
+ * @package   Audit
+ * @since     3.x
+ */
+class SettingsHandler extends Component
+{
+    public function onSettingsChanged(ConfigEvent $event, string $settingsType): bool
+    {
+        $auditService = Audit::$plugin->auditService;
+
+        return $auditService->catchSaveError(function() use ($event, $settingsType, $auditService) {
+            $model = $auditService->_getStandardModel();
+            $model->event = $settingsType === 'system'
+                ? AuditModel::EVENT_SYSTEM_SETTINGS_CHANGED
+                : AuditModel::EVENT_EMAIL_SETTINGS_CHANGED;
+            $model->title = ucfirst($settingsType) . ' settings';
+            $model->snapshot = $auditService->afterSnapshot($model, array_merge($model->snapshot, [
+                'settingsType' => $settingsType,
+                'path' => $event->path,
+                'oldValue' => $event->oldValue,
+                'newValue' => $event->newValue,
+            ]));
+
+            return $auditService->_saveRecord($model);
+        });
+    }
+}


### PR DESCRIPTION
Part of the v3 refactor stack for [FRE-56](https://linear.app/sanity/issue/FRE-56). Closes [FRE-131](https://linear.app/sanity/issue/fre-131).


**Diff:** 7 files changed, 500 insertions(+), 221 deletions(-)
**Tests:** 133 → 133 (+0 (refactor))
**Verified on fresh DB:** `DROP DATABASE; pest` green

### Stack navigation

↑ Builds on **#96** `decompose-elements-users-groups` (P2.1)
↓ Followed by **#98** `repoint-event-wiring-to-handlers` (P2.3)

### Review notes

- Single-commit branch — review the commit, not just the diff
- BC preserved — old `AuditService` API still works via @deprecated delegators
- This is a **draft** — not a request to merge yet. Marked ready when the stack is approved end-to-end.

