### PR TITLE
Phase 2.4 — Migrate Pest tests from AuditModel::EVENT_* to AuditEvent enum

### DIFF
--- a/tests/Feature/DatabaseEventsTest.php
+++ b/tests/Feature/DatabaseEventsTest.php
@@ -4,6 +4,7 @@ use craft\elements\User;
 use craft\events\BackupEvent;
 use craft\events\RestoreEvent;
 use superbig\audit\Audit;
+use superbig\audit\enums\AuditEvent;
 use superbig\audit\models\AuditModel;
 use superbig\audit\records\AuditRecord;
 
@@ -21,7 +22,7 @@ it('logs audit event when backup is created', function () {
     Audit::$plugin->auditService->onBackupCreated($event);
 
     $record = AuditRecord::find()
-        ->where(['event' => AuditModel::EVENT_BACKUP_CREATED])
+        ->where(['event' => AuditEvent::BackupCreated->value])
         ->one();
 
     expect($record)->not->toBeNull();
@@ -38,7 +39,7 @@ it('logs audit event when backup is restored', function () {
     Audit::$plugin->auditService->onBackupRestored($event);
 
     $record = AuditRecord::find()
-        ->where(['event' => AuditModel::EVENT_BACKUP_RESTORED])
+        ->where(['event' => AuditEvent::BackupRestored->value])
         ->one();
 
     expect($record)->not->toBeNull();
@@ -59,7 +60,7 @@ it('does not log database events when disabled', function () {
     expect($result)->toBeFalse();
 
     $record = AuditRecord::find()
-        ->where(['event' => AuditModel::EVENT_BACKUP_CREATED])
+        ->where(['event' => AuditEvent::BackupCreated->value])
         ->one();
 
     expect($record)->toBeNull();
@@ -78,7 +79,7 @@ it('captures backup file path in snapshot', function () {
     Audit::$plugin->auditService->onBackupCreated($event);
 
     $record = AuditRecord::find()
-        ->where(['event' => AuditModel::EVENT_BACKUP_CREATED])
+        ->where(['event' => AuditEvent::BackupCreated->value])
         ->one();
 
     $model = AuditModel::createFromRecord($record);
@@ -98,7 +99,7 @@ it('captures restore file path in snapshot', function () {
     Audit::$plugin->auditService->onBackupRestored($event);
 
     $record = AuditRecord::find()
-        ->where(['event' => AuditModel::EVENT_BACKUP_RESTORED])
+        ->where(['event' => AuditEvent::BackupRestored->value])
         ->one();
 
     $model = AuditModel::createFromRecord($record);

--- a/tests/Feature/ElementEventsTest.php
+++ b/tests/Feature/ElementEventsTest.php
@@ -4,6 +4,7 @@ use markhuot\craftpest\factories\Entry;
 use craft\elements\Entry as EntryElement;
 use craft\elements\GlobalSet;
 use superbig\audit\Audit;
+use superbig\audit\enums\AuditEvent;
 use superbig\audit\models\AuditModel;
 use superbig\audit\records\AuditRecord;
 
@@ -20,7 +21,7 @@ it('logs audit event when entry is created', function () {
         ->one();
 
     expect($record)->not->toBeNull();
-    expect($record->event)->toBe(AuditModel::EVENT_ENTRY_CREATED);
+    expect($record->event)->toBe(AuditEvent::EntryCreated->value);
     expect($record->elementType)->toBe(EntryElement::class);
 });
 
@@ -39,7 +40,7 @@ it('logs audit event when entry is updated', function () {
         ->one();
 
     expect($record)->not->toBeNull();
-    expect($record->event)->toBe(AuditModel::EVENT_ENTRY_SAVED);
+    expect($record->event)->toBe(AuditEvent::EntrySaved->value);
 });
 
 it('logs audit event when entry is deleted', function () {
@@ -57,7 +58,7 @@ it('logs audit event when entry is deleted', function () {
         ->one();
 
     expect($record)->not->toBeNull();
-    expect($record->event)->toBe(AuditModel::EVENT_ENTRY_DELETED);
+    expect($record->event)->toBe(AuditEvent::EntryDeleted->value);
 });
 
 it('does not log draft events when disabled', function () {
@@ -70,7 +71,7 @@ it('does not log draft events when disabled', function () {
     $draft = \Craft::$app->getDrafts()->createDraft($entry, \Craft::$app->getUser()->getId());
 
     $draftRecord = AuditRecord::find()
-        ->where(['event' => AuditModel::EVENT_SAVED_DRAFT])
+        ->where(['event' => AuditEvent::SavedDraft->value])
         ->one();
 
     expect($draftRecord)->toBeNull();
@@ -99,7 +100,7 @@ it('logs global set saves', function () {
     \Craft::$app->getElements()->saveElement($globals);
 
     $record = AuditRecord::find()
-        ->where(['event' => AuditModel::EVENT_SAVED_GLOBAL])
+        ->where(['event' => AuditEvent::SavedGlobal->value])
         ->one();
 
     expect($record)->not->toBeNull();

--- a/tests/Feature/PermissionEventsTest.php
+++ b/tests/Feature/PermissionEventsTest.php
@@ -6,6 +6,7 @@ use craft\events\UserGroupPermissionsEvent;
 use craft\events\UserPermissionsEvent;
 use craft\models\UserGroup;
 use superbig\audit\Audit;
+use superbig\audit\enums\AuditEvent;
 use superbig\audit\models\AuditModel;
 use superbig\audit\records\AuditRecord;
 
@@ -24,7 +25,7 @@ it('logs audit event when user permissions are saved', function () {
     Audit::$plugin->auditService->onUserPermissionsSaved($event);
 
     $record = AuditRecord::find()
-        ->where(['event' => AuditModel::EVENT_USER_PERMISSIONS_SAVED])
+        ->where(['event' => AuditEvent::UserPermissionsSaved->value])
         ->one();
 
     expect($record)->not->toBeNull();
@@ -42,7 +43,7 @@ it('logs audit event when group permissions are saved', function () {
     Audit::$plugin->auditService->onGroupPermissionsSaved($event);
 
     $record = AuditRecord::find()
-        ->where(['event' => AuditModel::EVENT_GROUP_PERMISSIONS_SAVED])
+        ->where(['event' => AuditEvent::GroupPermissionsSaved->value])
         ->one();
 
     expect($record)->not->toBeNull();
@@ -63,7 +64,7 @@ it('logs audit event when user group is saved', function () {
     Audit::$plugin->auditService->onUserGroupSaved($event);
 
     $record = AuditRecord::find()
-        ->where(['event' => AuditModel::EVENT_USER_GROUP_CREATED])
+        ->where(['event' => AuditEvent::UserGroupCreated->value])
         ->one();
 
     expect($record)->not->toBeNull();
@@ -84,7 +85,7 @@ it('logs audit event when user group is deleted', function () {
     Audit::$plugin->auditService->onUserGroupDeleted($event);
 
     $record = AuditRecord::find()
-        ->where(['event' => AuditModel::EVENT_USER_GROUP_DELETED])
+        ->where(['event' => AuditEvent::UserGroupDeleted->value])
         ->one();
 
     expect($record)->not->toBeNull();
@@ -106,7 +107,7 @@ it('does not log permission events when disabled', function () {
     expect($result)->toBeFalse();
 
     $record = AuditRecord::find()
-        ->where(['event' => AuditModel::EVENT_USER_PERMISSIONS_SAVED])
+        ->where(['event' => AuditEvent::UserPermissionsSaved->value])
         ->one();
 
     expect($record)->toBeNull();
@@ -126,7 +127,7 @@ it('captures permissions in snapshot', function () {
     Audit::$plugin->auditService->onUserPermissionsSaved($event);
 
     $record = AuditRecord::find()
-        ->where(['event' => AuditModel::EVENT_USER_PERMISSIONS_SAVED])
+        ->where(['event' => AuditEvent::UserPermissionsSaved->value])
         ->one();
 
     $model = AuditModel::createFromRecord($record);

--- a/tests/Feature/PluginEventsTest.php
+++ b/tests/Feature/PluginEventsTest.php
@@ -1,6 +1,7 @@
 <?php
 
 use superbig\audit\Audit;
+use superbig\audit\enums\AuditEvent;
 use superbig\audit\models\AuditModel;
 use superbig\audit\records\AuditRecord;
 
@@ -17,12 +18,12 @@ it('logs audit event when plugin is enabled', function () {
     };
 
     Audit::$plugin->auditService->onPluginEvent(
-        AuditModel::EVENT_PLUGIN_ENABLED,
+        AuditEvent::PluginEnabled->value,
         $mockPlugin
     );
 
     $record = AuditRecord::find()
-        ->where(['event' => AuditModel::EVENT_PLUGIN_ENABLED])
+        ->where(['event' => AuditEvent::PluginEnabled->value])
         ->one();
 
     expect($record)->not->toBeNull();
@@ -36,12 +37,12 @@ it('logs audit event when plugin is disabled', function () {
     };
 
     Audit::$plugin->auditService->onPluginEvent(
-        AuditModel::EVENT_PLUGIN_DISABLED,
+        AuditEvent::PluginDisabled->value,
         $mockPlugin
     );
 
     $record = AuditRecord::find()
-        ->where(['event' => AuditModel::EVENT_PLUGIN_DISABLED])
+        ->where(['event' => AuditEvent::PluginDisabled->value])
         ->one();
 
     expect($record)->not->toBeNull();
@@ -56,7 +57,7 @@ it('does not log plugin events when disabled', function () {
     };
 
     $result = Audit::$plugin->auditService->onPluginEvent(
-        AuditModel::EVENT_PLUGIN_ENABLED,
+        AuditEvent::PluginEnabled->value,
         $mockPlugin
     );
 
@@ -73,12 +74,12 @@ it('captures plugin info in snapshot', function () {
     };
 
     Audit::$plugin->auditService->onPluginEvent(
-        AuditModel::EVENT_PLUGIN_ENABLED,
+        AuditEvent::PluginEnabled->value,
         $mockPlugin
     );
 
     $record = AuditRecord::find()
-        ->where(['event' => AuditModel::EVENT_PLUGIN_ENABLED])
+        ->where(['event' => AuditEvent::PluginEnabled->value])
         ->one();
 
     $model = AuditModel::createFromRecord($record);

--- a/tests/Feature/RouteEventsTest.php
+++ b/tests/Feature/RouteEventsTest.php
@@ -2,6 +2,7 @@
 
 use craft\events\RouteEvent;
 use superbig\audit\Audit;
+use superbig\audit\enums\AuditEvent;
 use superbig\audit\models\AuditModel;
 use superbig\audit\records\AuditRecord;
 
@@ -20,7 +21,7 @@ it('logs audit event when route is saved', function () {
     Audit::$plugin->auditService->onSaveRoute($event);
 
     $record = AuditRecord::find()
-        ->where(['event' => AuditModel::EVENT_SAVED_ROUTE])
+        ->where(['event' => AuditEvent::SavedRoute->value])
         ->one();
 
     expect($record)->not->toBeNull();
@@ -37,7 +38,7 @@ it('logs audit event when route is deleted', function () {
     Audit::$plugin->auditService->onDeleteRoute($event);
 
     $record = AuditRecord::find()
-        ->where(['event' => AuditModel::EVENT_DELETED_ROUTE])
+        ->where(['event' => AuditEvent::DeletedRoute->value])
         ->one();
 
     expect($record)->not->toBeNull();
@@ -59,7 +60,7 @@ it('captures site UID in route snapshot', function () {
     Audit::$plugin->auditService->onSaveRoute($event);
 
     $record = AuditRecord::find()
-        ->where(['event' => AuditModel::EVENT_SAVED_ROUTE])
+        ->where(['event' => AuditEvent::SavedRoute->value])
         ->one();
 
     $model = AuditModel::createFromRecord($record);

--- a/tests/Feature/SchemaEventsTest.php
+++ b/tests/Feature/SchemaEventsTest.php
@@ -8,6 +8,7 @@ use craft\fields\PlainText;
 use craft\models\EntryType;
 use craft\models\Section;
 use superbig\audit\Audit;
+use superbig\audit\enums\AuditEvent;
 use superbig\audit\models\AuditModel;
 use superbig\audit\records\AuditRecord;
 
@@ -30,7 +31,7 @@ it('logs audit event when field is saved', function () {
     Audit::$plugin->auditService->onFieldSaved($event);
 
     $record = AuditRecord::find()
-        ->where(['event' => AuditModel::EVENT_FIELD_CREATED])
+        ->where(['event' => AuditEvent::FieldCreated->value])
         ->one();
 
     expect($record)->not->toBeNull();
@@ -51,7 +52,7 @@ it('logs audit event when field is deleted', function () {
     Audit::$plugin->auditService->onFieldDeleted($event);
 
     $record = AuditRecord::find()
-        ->where(['event' => AuditModel::EVENT_FIELD_DELETED])
+        ->where(['event' => AuditEvent::FieldDeleted->value])
         ->one();
 
     expect($record)->not->toBeNull();
@@ -74,7 +75,7 @@ it('logs audit event when section is saved', function () {
     Audit::$plugin->auditService->onSectionSaved($event);
 
     $record = AuditRecord::find()
-        ->where(['event' => AuditModel::EVENT_SECTION_CREATED])
+        ->where(['event' => AuditEvent::SectionCreated->value])
         ->one();
 
     expect($record)->not->toBeNull();
@@ -95,7 +96,7 @@ it('logs audit event when section is deleted', function () {
     Audit::$plugin->auditService->onSectionDeleted($event);
 
     $record = AuditRecord::find()
-        ->where(['event' => AuditModel::EVENT_SECTION_DELETED])
+        ->where(['event' => AuditEvent::SectionDeleted->value])
         ->one();
 
     expect($record)->not->toBeNull();
@@ -117,7 +118,7 @@ it('logs audit event when entry type is saved', function () {
     Audit::$plugin->auditService->onEntryTypeSaved($event);
 
     $record = AuditRecord::find()
-        ->where(['event' => AuditModel::EVENT_ENTRY_TYPE_CREATED])
+        ->where(['event' => AuditEvent::EntryTypeCreated->value])
         ->one();
 
     expect($record)->not->toBeNull();
@@ -138,7 +139,7 @@ it('logs audit event when entry type is deleted', function () {
     Audit::$plugin->auditService->onEntryTypeDeleted($event);
 
     $record = AuditRecord::find()
-        ->where(['event' => AuditModel::EVENT_ENTRY_TYPE_DELETED])
+        ->where(['event' => AuditEvent::EntryTypeDeleted->value])
         ->one();
 
     expect($record)->not->toBeNull();
@@ -164,7 +165,7 @@ it('does not log schema events when disabled', function () {
     expect($result)->toBeFalse();
 
     $record = AuditRecord::find()
-        ->where(['event' => AuditModel::EVENT_FIELD_SAVED])
+        ->where(['event' => AuditEvent::FieldSaved->value])
         ->one();
 
     expect($record)->toBeNull();
@@ -187,7 +188,7 @@ it('captures field details in snapshot', function () {
     Audit::$plugin->auditService->onFieldSaved($event);
 
     $record = AuditRecord::find()
-        ->where(['event' => AuditModel::EVENT_FIELD_CREATED])
+        ->where(['event' => AuditEvent::FieldCreated->value])
         ->one();
 
     $model = AuditModel::createFromRecord($record);

--- a/tests/Feature/UserEventsTest.php
+++ b/tests/Feature/UserEventsTest.php
@@ -2,7 +2,7 @@
 
 use craft\elements\User;
 use superbig\audit\Audit;
-use superbig\audit\models\AuditModel;
+use superbig\audit\enums\AuditEvent;
 use superbig\audit\records\AuditRecord;
 
 beforeEach(function () {
@@ -20,7 +20,7 @@ it('logs audit event when user logs in', function () {
     Audit::$plugin->auditService->onLogin();
 
     $record = AuditRecord::find()
-        ->where(['event' => AuditModel::USER_LOGGED_IN])
+        ->where(['event' => AuditEvent::UserLoggedIn->value])
         ->one();
 
     expect($record)->not->toBeNull();
@@ -37,7 +37,7 @@ it('logs audit event when user logs out', function () {
     Audit::$plugin->auditService->onBeforeLogout();
 
     $record = AuditRecord::find()
-        ->where(['event' => AuditModel::USER_LOGGED_OUT])
+        ->where(['event' => AuditEvent::UserLoggedOut->value])
         ->one();
 
     expect($record)->not->toBeNull();
@@ -57,7 +57,7 @@ it('does not log user events when disabled', function () {
     expect($result)->toBeFalse();
 
     $record = AuditRecord::find()
-        ->where(['event' => AuditModel::USER_LOGGED_IN])
+        ->where(['event' => AuditEvent::UserLoggedIn->value])
         ->one();
 
     expect($record)->toBeNull();
@@ -73,7 +73,7 @@ it('captures session ID on login event', function () {
     Audit::$plugin->auditService->onLogin();
 
     $record = AuditRecord::find()
-        ->where(['event' => AuditModel::USER_LOGGED_IN])
+        ->where(['event' => AuditEvent::UserLoggedIn->value])
         ->one();
 
     expect($record)->not->toBeNull();

--- a/tests/Feature/UserSecurityEventsTest.php
+++ b/tests/Feature/UserSecurityEventsTest.php
@@ -3,6 +3,7 @@
 use craft\elements\User;
 use craft\events\UserEvent;
 use superbig\audit\Audit;
+use superbig\audit\enums\AuditEvent;
 use superbig\audit\models\AuditModel;
 use superbig\audit\records\AuditRecord;
 
@@ -18,7 +19,7 @@ it('logs audit event when user is activated', function () {
     Audit::$plugin->auditService->onUserActivated($event);
 
     $record = AuditRecord::find()
-        ->where(['event' => AuditModel::EVENT_USER_ACTIVATED])
+        ->where(['event' => AuditEvent::UserActivated->value])
         ->one();
 
     expect($record)->not->toBeNull();
@@ -34,7 +35,7 @@ it('logs audit event when user is deactivated', function () {
     Audit::$plugin->auditService->onUserDeactivated($event);
 
     $record = AuditRecord::find()
-        ->where(['event' => AuditModel::EVENT_USER_DEACTIVATED])
+        ->where(['event' => AuditEvent::UserDeactivated->value])
         ->one();
 
     expect($record)->not->toBeNull();
@@ -49,7 +50,7 @@ it('logs audit event when user is suspended', function () {
     Audit::$plugin->auditService->onUserSuspended($event);
 
     $record = AuditRecord::find()
-        ->where(['event' => AuditModel::EVENT_USER_SUSPENDED])
+        ->where(['event' => AuditEvent::UserSuspended->value])
         ->one();
 
     expect($record)->not->toBeNull();
@@ -64,7 +65,7 @@ it('logs audit event when user is unsuspended', function () {
     Audit::$plugin->auditService->onUserUnsuspended($event);
 
     $record = AuditRecord::find()
-        ->where(['event' => AuditModel::EVENT_USER_UNSUSPENDED])
+        ->where(['event' => AuditEvent::UserUnsuspended->value])
         ->one();
 
     expect($record)->not->toBeNull();
@@ -79,7 +80,7 @@ it('logs audit event when user is locked', function () {
     Audit::$plugin->auditService->onUserLocked($event);
 
     $record = AuditRecord::find()
-        ->where(['event' => AuditModel::EVENT_USER_LOCKED])
+        ->where(['event' => AuditEvent::UserLocked->value])
         ->one();
 
     expect($record)->not->toBeNull();
@@ -94,7 +95,7 @@ it('logs audit event when user is unlocked', function () {
     Audit::$plugin->auditService->onUserUnlocked($event);
 
     $record = AuditRecord::find()
-        ->where(['event' => AuditModel::EVENT_USER_UNLOCKED])
+        ->where(['event' => AuditEvent::UserUnlocked->value])
         ->one();
 
     expect($record)->not->toBeNull();
@@ -113,7 +114,7 @@ it('does not log user security events when disabled', function () {
     expect($result)->toBeFalse();
 
     $record = AuditRecord::find()
-        ->where(['event' => AuditModel::EVENT_USER_ACTIVATED])
+        ->where(['event' => AuditEvent::UserActivated->value])
         ->one();
 
     expect($record)->toBeNull();
@@ -129,7 +130,7 @@ it('captures user details in snapshot', function () {
     Audit::$plugin->auditService->onUserActivated($event);
 
     $record = AuditRecord::find()
-        ->where(['event' => AuditModel::EVENT_USER_ACTIVATED])
+        ->where(['event' => AuditEvent::UserActivated->value])
         ->one();
 
     expect($record)->not->toBeNull();


### PR DESCRIPTION
Part of the v3 refactor stack for [FRE-56](https://linear.app/sanity/issue/FRE-56). Closes [FRE-133](https://linear.app/sanity/issue/fre-133).


**Diff:** 8 files changed, 54 insertions(+), 47 deletions(-)
**Tests:** 133 → 133 (+0 (test migration))
**Verified on fresh DB:** `DROP DATABASE; pest` green

### Stack navigation

↑ Builds on **#98** `repoint-event-wiring-to-handlers` (P2.3)
↓ Top of currently-pushed stack — two more branches (CI + P3.0 docs) blocked on a token-scope upgrade and will follow once granted

### Review notes

- Single-commit branch — review the commit, not just the diff
- BC preserved — old `AuditService` API still works via @deprecated delegators
- This is a **draft** — not a request to merge yet. Marked ready when the stack is approved end-to-end.

