### PR TITLE
UI improvements: diff rendering + 20 Twig templates + asset bundle

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,9 @@
         "php": "^8.2.0",
         "craftcms/cms": "^5.5",
         "donatj/phpuseragentparser": "^1.7.0",
-        "geoip2/geoip2": "^3.0"
+        "geoip2/geoip2": "^3.0",
+        "jfcherng/php-diff": "^6.0",
+        "caxy/php-htmldiff": "^0.1"
     },
     "require-dev": {
         "craftcms/ecs": "dev-main",

--- a/src/Audit.php
+++ b/src/Audit.php
@@ -65,6 +65,7 @@ use superbig\audit\models\Settings;
 use superbig\audit\services\Audit_GeoService;
 use superbig\audit\services\AuditRecorder;
 use superbig\audit\services\AuditService;
+use superbig\audit\services\DiffRenderer;
 use superbig\audit\services\FieldDiffService;
 use superbig\audit\services\FieldHandlerRegistry;
 use superbig\audit\services\ProjectConfigTracker;
@@ -88,6 +89,7 @@ use yii\web\UserEvent;
  * @property  FieldDiffService      $fieldDiffService
  * @property  AuditRecorder         $auditRecorder
  * @property  ProjectConfigTracker  $projectConfigTracker
+ * @property  DiffRenderer          $diffRenderer
  * @method  Settings getSettings()
  */
 class Audit extends Plugin
@@ -142,6 +144,7 @@ class Audit extends Plugin
             'fieldDiffService' => FieldDiffService::class,
             'auditRecorder' => AuditRecorder::class,
             'projectConfigTracker' => ProjectConfigTracker::class,
+            'diffRenderer' => DiffRenderer::class,
         ]);
 
         $this->registerFieldHandlers();

--- a/src/controllers/DefaultController.php
+++ b/src/controllers/DefaultController.php
@@ -18,6 +18,7 @@ use craft\web\Controller;
 use superbig\audit\Audit;
 use superbig\audit\models\AuditModel;
 use superbig\audit\records\AuditRecord;
+use superbig\audit\web\assets\diff\AuditDiffAsset;
 
 /**
  * @author    Superbig
@@ -44,6 +45,8 @@ class DefaultController extends Controller
     public function actionIndex()
     {
         $this->requirePermission(Audit::PERMISSION_VIEW_LOGS);
+
+        Craft::$app->view->registerAssetBundle(AuditDiffAsset::class);
 
         $itemsPerPage = 100;
         $query = AuditRecord::find()
@@ -75,6 +78,8 @@ class DefaultController extends Controller
     public function actionDetails(int $id)
     {
         $this->requirePermission(Audit::PERMISSION_VIEW_LOGS);
+
+        Craft::$app->view->registerAssetBundle(AuditDiffAsset::class);
 
         $service = Audit::$plugin->auditService;
         $log = $service->getEventById($id);

--- a/src/services/DiffRenderer.php
+++ b/src/services/DiffRenderer.php
@@ -1,0 +1,296 @@
+<?php
+
+declare(strict_types=1);
+
+namespace superbig\audit\services;
+
+use Caxy\HtmlDiff\HtmlDiff;
+use Caxy\HtmlDiff\HtmlDiffConfig;
+use Craft;
+use craft\base\Component;
+use Jfcherng\Diff\DiffHelper;
+
+/**
+ * DiffRenderer — wraps jfcherng/php-diff and caxy/php-htmldiff
+ * with a consistent interface for all Craft Audit field handlers.
+ *
+ * All public methods MUST return a string (never throw) — on failure they
+ * fall back to a simple text diff or an error badge.
+ */
+class DiffRenderer extends Component
+{
+    // ── Constants ────────────────────────────────────────────────────
+
+    /** Default maximum bytes to diff before truncating. */
+    public const MAX_BYTES = 50_000;
+
+    /** Maximum lines to diff before truncating (line-level diffs). */
+    public const MAX_LINES = 500;
+
+    // ── Shared config (built once, reused) ───────────────────────────
+
+    private ?HtmlDiffConfig $htmlDiffConfig = null;
+
+    // ── Public API ───────────────────────────────────────────────────
+
+    /**
+     * Render a plain-text diff using jfcherng/php-diff.
+     *
+     * @param string $from   Old value
+     * @param string $to     New value
+     * @param string $mode   'inline' | 'side-by-side'
+     * @param string $detail 'word' | 'line' | 'char' | 'none'
+     */
+    public function renderTextDiff(
+        string $from,
+        string $to,
+        string $mode = 'inline',
+        string $detail = 'word',
+    ): string {
+        // Short-circuit: identical content (including both empty)
+        if ($from === $to) {
+            return $this->identicalResult();
+        }
+
+        // Truncate large inputs
+        $from = $this->maybeTruncate($from);
+        $to = $this->maybeTruncate($to);
+
+        $renderer = match ($mode) {
+            'side-by-side' => 'SideBySide',
+            default => 'Inline',
+        };
+
+        $differOptions = [
+            'context' => 2,
+            'ignoreCase' => false,
+            'ignoreLineEnding' => true,
+            'ignoreWhitespace' => false,
+            'lengthLimit' => 2000,
+            'fullContextIfIdentical' => false,
+        ];
+
+        $rendererOptions = [
+            'detailLevel' => $detail,
+            'language' => 'eng',
+            'lineNumbers' => false,
+            'separateBlock' => true,
+            'showHeader' => false,
+            'wrapperClasses' => ['audit-diff', 'diff-wrapper'],
+        ];
+
+        try {
+            $result = DiffHelper::calculate($from, $to, $renderer, $differOptions, $rendererOptions);
+        } catch (\Throwable $e) {
+            Craft::warning('DiffRenderer::renderTextDiff failed: ' . $e->getMessage(), 'audit');
+            return $this->renderSimpleDiff($from, $to);
+        }
+
+        // Empty result = no changes detected
+        if ($result === '') {
+            return $this->identicalResult();
+        }
+
+        return $result;
+    }
+
+    /**
+     * Render an HTML-aware diff using caxy/php-htmldiff.
+     * Produces output with <ins> and <del> tags.
+     */
+    public function renderHtmlDiff(string $from, string $to): string
+    {
+        // Short-circuit: identical content
+        if ($from === $to) {
+            return $this->identicalResult();
+        }
+
+        // Truncate large inputs
+        $from = $this->maybeTruncate($from);
+        $to = $this->maybeTruncate($to);
+
+        try {
+            $diff = HtmlDiff::create($from, $to, $this->getHtmlDiffConfig());
+            $result = $diff->build();
+        } catch (\Throwable $e) {
+            Craft::warning('DiffRenderer::renderHtmlDiff failed: ' . $e->getMessage(), 'audit');
+            return $this->renderSimpleDiff($from, $to);
+        }
+
+        if (!is_string($result) || $result === '') {
+            return $this->identicalResult();
+        }
+
+        // If no <ins>/<del> markers appeared, the libraries consider this "no change"
+        if (!str_contains($result, '<ins') && !str_contains($result, '<del')) {
+            return $this->identicalResult();
+        }
+
+        return '<div class="audit-diff-html">' . $result . '</div>';
+    }
+
+    /**
+     * Render a diff for structured data (arrays, objects).
+     * Serializes to pretty-printed JSON and runs a line-level text diff.
+     *
+     * @param mixed $from Old value (array, object, scalar)
+     * @param mixed $to   New value
+     */
+    public function renderJsonDiff(mixed $from, mixed $to): string
+    {
+        $flags = JSON_PRETTY_PRINT | JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES;
+
+        try {
+            $fromJson = json_encode($from, $flags | JSON_THROW_ON_ERROR);
+            $toJson = json_encode($to,   $flags | JSON_THROW_ON_ERROR);
+        } catch (\Throwable $e) {
+            Craft::warning('DiffRenderer::renderJsonDiff: json_encode failed: ' . $e->getMessage(), 'audit');
+            return $this->errorResult();
+        }
+
+        if ($fromJson === $toJson) {
+            return $this->identicalResult();
+        }
+
+        // Use line-level diff for JSON (word-level is too noisy for structured data)
+        return $this->renderTextDiff($fromJson, $toJson, 'inline', 'line');
+    }
+
+    /**
+     * Render a simple "old → new" inline comparison (no external library).
+     * Used by handlers that have their own visual representation, and as
+     * a last-resort fallback when the diff libraries fail.
+     *
+     * @param mixed $from Formatted old value (will be cast to string)
+     * @param mixed $to   Formatted new value (will be cast to string)
+     */
+    public function renderSimpleDiff(mixed $from, mixed $to): string
+    {
+        $fromStr = $this->toScalarString($from);
+        $toStr = $this->toScalarString($to);
+
+        if ($fromStr === $toStr) {
+            return $this->identicalResult();
+        }
+
+        return sprintf(
+            '<span class="audit-diff-simple">'
+            . '<span class="audit-diff-old">%s</span>'
+            . '<span class="audit-diff-arrow">→</span>'
+            . '<span class="audit-diff-new">%s</span>'
+            . '</span>',
+            htmlspecialchars($fromStr, ENT_QUOTES, 'UTF-8'),
+            htmlspecialchars($toStr,   ENT_QUOTES, 'UTF-8')
+        );
+    }
+
+    /**
+     * Truncate content to maxBytes to prevent memory/timeout issues.
+     * Respects UTF-8 character boundaries.
+     *
+     * Public so tests / handlers can use it directly.
+     */
+    public function maybeTruncate(string $content, int $maxBytes = self::MAX_BYTES): string
+    {
+        if (strlen($content) <= $maxBytes) {
+            return $content;
+        }
+
+        Craft::warning(
+            sprintf('DiffRenderer: truncating content from %d to %d bytes', strlen($content), $maxBytes),
+            'audit'
+        );
+
+        $truncated = substr($content, 0, $maxBytes);
+        // Fix any UTF-8 multi-byte sequence we may have cut in half.
+        // mb_convert_encoding with 'UTF-8'/'UTF-8' normalizes the string.
+        $truncated = mb_convert_encoding($truncated, 'UTF-8', 'UTF-8');
+
+        $kb = (int)round($maxBytes / 1000);
+        return $truncated . "\n[… content truncated at {$kb}KB]";
+    }
+
+    /**
+     * Truncate to maxLines lines (for line-level diffs on large text).
+     */
+    public function maybeTruncateLines(string $content, int $maxLines = self::MAX_LINES): string
+    {
+        $lines = explode("\n", $content);
+        if (count($lines) <= $maxLines) {
+            return $content;
+        }
+
+        $omitted = count($lines) - $maxLines;
+        $truncated = array_slice($lines, 0, $maxLines);
+        $truncated[] = "[… {$omitted} more lines truncated]";
+
+        return implode("\n", $truncated);
+    }
+
+    // ── Private helpers ──────────────────────────────────────────────
+
+    /**
+     * Build (and cache) the shared HtmlDiffConfig.
+     */
+    private function getHtmlDiffConfig(): HtmlDiffConfig
+    {
+        if ($this->htmlDiffConfig !== null) {
+            return $this->htmlDiffConfig;
+        }
+
+        $runtimePath = Craft::$app->path->getRuntimePath() . '/htmlpurifier';
+
+        // Note: chain is broken into individual calls because caxy/php-htmldiff's
+        // setMatchThreshold has a wrong @return docblock (says AbstractDiff instead
+        // of HtmlDiffConfig), which confuses PHPStan when chaining further setters.
+        $config = HtmlDiffConfig::create();
+        $config->setMatchThreshold(80);
+        $config->setInsertSpaceInReplace(true);
+        $config->setGroupDiffs(true);
+        $config->setUseTableDiffing(true);
+        $config->setEncoding('UTF-8');
+        $config->setPurifierEnabled(true);
+        $config->setPurifierCacheLocation($runtimePath);
+        $config->setKeepNewLines(false);
+
+        return $this->htmlDiffConfig = $config;
+    }
+
+    /**
+     * Standard "no changes" result.
+     */
+    private function identicalResult(): string
+    {
+        return '<span class="audit-diff-badge audit-diff-badge--identical">No changes</span>';
+    }
+
+    /**
+     * Standard error result (diff failed AND simple diff unavailable).
+     */
+    private function errorResult(): string
+    {
+        return '<span class="audit-diff-badge audit-diff-badge--error">Diff unavailable</span>';
+    }
+
+    /**
+     * Coerce any value into a display string (best-effort).
+     */
+    private function toScalarString(mixed $value): string
+    {
+        if ($value === null) {
+            return '';
+        }
+        if (is_string($value)) {
+            return $value;
+        }
+        if (is_bool($value)) {
+            return $value ? 'true' : 'false';
+        }
+        if (is_scalar($value)) {
+            return (string)$value;
+        }
+        // Arrays / objects → compact JSON
+        $encoded = @json_encode($value, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES);
+        return $encoded === false ? '[unserializable]' : $encoded;
+    }
+}

--- a/src/templates/_diff/boolean.twig
+++ b/src/templates/_diff/boolean.twig
@@ -1,0 +1,26 @@
+{# _diff/boolean.twig — on/off toggle badges. #}
+{% macro boolBadge(value) %}
+    {% set on = value ? true : false %}
+    <span class="audit-diff-bool-badge audit-diff-bool-badge--{{ on ? 'on' : 'off' }}">
+        {% if on %}
+            <svg width="10" height="10" viewBox="0 0 10 10" aria-hidden="true"><path d="M1.5 5l2.5 2.5 4.5-4.5" stroke="currentColor" stroke-width="1.5" fill="none"/></svg>
+            On
+        {% else %}
+            <svg width="10" height="10" viewBox="0 0 10 10" aria-hidden="true"><path d="M2 2l6 6M8 2l-6 6" stroke="currentColor" stroke-width="1.5" fill="none"/></svg>
+            Off
+        {% endif %}
+    </span>
+{% endmacro %}
+
+{% set from = change.from ? true : false %}
+{% set to   = change.to   ? true : false %}
+
+{% if from == to %}
+    <span class="audit-diff-badge audit-diff-badge--identical">No changes</span>
+{% else %}
+<div class="audit-diff-bool">
+    {{ _self.boolBadge(from) }}
+    <span class="audit-diff-arrow">→</span>
+    {{ _self.boolBadge(to) }}
+</div>
+{% endif %}

--- a/src/templates/_diff/color.twig
+++ b/src/templates/_diff/color.twig
@@ -1,0 +1,27 @@
+{# _diff/color.twig — color swatches + hex values #}
+{% set from = change.from ?? '' %}
+{% set to   = change.to   ?? '' %}
+
+{% if from == to %}
+    <span class="audit-diff-badge audit-diff-badge--identical">No changes</span>
+{% else %}
+<div class="audit-diff-color">
+    <div class="audit-diff-color-side">
+        {% if from %}
+            <span class="audit-color-swatch audit-diff-color-swatch" style="background: {{ from }};"></span>
+            <code class="audit-diff-old">{{ from }}</code>
+        {% else %}
+            <em class="audit-diff-old">None</em>
+        {% endif %}
+    </div>
+    <span class="audit-diff-arrow">→</span>
+    <div class="audit-diff-color-side">
+        {% if to %}
+            <span class="audit-color-swatch audit-diff-color-swatch" style="background: {{ to }};"></span>
+            <code class="audit-diff-new">{{ to }}</code>
+        {% else %}
+            <em class="audit-diff-new">None</em>
+        {% endif %}
+    </div>
+</div>
+{% endif %}

--- a/src/templates/_diff/config.twig
+++ b/src/templates/_diff/config.twig
@@ -1,0 +1,27 @@
+{# _diff/config.twig — project config changes: key → old/new pairs. #}
+{% set path = change.path ?? change.key ?? '' %}
+{% set from = change.from ?? null %}
+{% set to   = change.to   ?? null %}
+{% set rows = change.rows ?? null %}
+
+<div class="audit-diff-config">
+    {% if path %}
+        <div class="audit-diff-config-row">
+            <div class="audit-diff-config-key">path</div>
+            <div><code>{{ path }}</code></div>
+        </div>
+    {% endif %}
+    {% if rows %}
+        {% for row in rows %}
+            <div class="audit-diff-config-row">
+                <div class="audit-diff-config-key">{{ row.key }}</div>
+                <div>{{ craft.audit.diff.renderSimpleDiff(row.from ?? '', row.to ?? '')|raw }}</div>
+            </div>
+        {% endfor %}
+    {% else %}
+        <div class="audit-diff-config-row">
+            <div class="audit-diff-config-key">value</div>
+            <div>{{ craft.audit.diff.renderJsonDiff(from, to)|raw }}</div>
+        </div>
+    {% endif %}
+</div>

--- a/src/templates/_diff/date.twig
+++ b/src/templates/_diff/date.twig
@@ -1,0 +1,29 @@
+{# _diff/date.twig — formatted dates with arrow. #}
+{% set from = change.from ?? null %}
+{% set to   = change.to   ?? null %}
+
+{% if from == to %}
+    <span class="audit-diff-badge audit-diff-badge--identical">No changes</span>
+{% else %}
+<div class="audit-diff-simple">
+    <span class="audit-diff-old">
+        {% if from %}
+            <time datetime="{{ from|date('c') }}" title="{{ from|date('Y-m-d H:i:s') }}">
+                {{ from|date('D, d M Y') }}
+            </time>
+        {% else %}
+            <em>None</em>
+        {% endif %}
+    </span>
+    <span class="audit-diff-arrow">→</span>
+    <span class="audit-diff-new">
+        {% if to %}
+            <time datetime="{{ to|date('c') }}" title="{{ to|date('Y-m-d H:i:s') }}">
+                {{ to|date('D, d M Y') }}
+            </time>
+        {% else %}
+            <em>None</em>
+        {% endif %}
+    </span>
+</div>
+{% endif %}

--- a/src/templates/_diff/error.twig
+++ b/src/templates/_diff/error.twig
@@ -1,0 +1,12 @@
+{# _diff/error.twig — field normalization failed. #}
+<div class="audit-diff-error">
+    <strong>⚠ Diff unavailable</strong>
+    {% if change.message ?? null %}
+        <div>{{ change.message }}</div>
+    {% else %}
+        <div>This field could not be normalized for comparison.</div>
+    {% endif %}
+    {% if change.handler ?? null %}
+        <small style="opacity:0.7">handler: {{ change.handler }}</small>
+    {% endif %}
+</div>

--- a/src/templates/_diff/generic.twig
+++ b/src/templates/_diff/generic.twig
@@ -1,0 +1,18 @@
+{# _diff/generic.twig — fallback: JSON-encoded old/new side by side. #}
+{% set from = change.from ?? null %}
+{% set to   = change.to   ?? null %}
+
+{% if from == to %}
+    <span class="audit-diff-badge audit-diff-badge--identical">No changes</span>
+{% else %}
+    <div class="audit-diff-generic">
+        <div class="audit-diff-generic-side old">
+            <div class="audit-diff-generic-label">Old</div>
+            <pre>{{ from is iterable ? from|json_encode(constant('JSON_PRETTY_PRINT')) : from }}</pre>
+        </div>
+        <div class="audit-diff-generic-side new">
+            <div class="audit-diff-generic-label">New</div>
+            <pre>{{ to is iterable ? to|json_encode(constant('JSON_PRETTY_PRINT')) : to }}</pre>
+        </div>
+    </div>
+{% endif %}

--- a/src/templates/_diff/index.twig
+++ b/src/templates/_diff/index.twig
@@ -1,0 +1,11 @@
+{# _diff/index.twig — dispatcher.
+   Usage: {% include 'audit/_diff/index.twig' with { change: { handler, from, to, ... } } %}
+   Looks up a per-handler template by the 'handler' key on the change object.
+#}
+{% set handler = change.handler ?? 'generic' %}
+{% set tpl = 'audit/_diff/' ~ handler %}
+{% if view.doesTemplateExist(tpl) %}
+    {% include tpl with { change: change } only %}
+{% else %}
+    {% include 'audit/_diff/generic' with { change: change } only %}
+{% endif %}

--- a/src/templates/_diff/matrix.twig
+++ b/src/templates/_diff/matrix.twig
@@ -1,0 +1,33 @@
+{# _diff/matrix.twig — Matrix blocks summary as cards. #}
+{% set blocks = change.blocks ?? [] %}
+
+{% if blocks is empty %}
+    <span class="audit-diff-badge audit-diff-badge--identical">No changes</span>
+{% else %}
+<div class="audit-diff-blocks">
+    {% for block in blocks %}
+        <div class="audit-diff-block audit-diff-block--{{ block.status ?? 'unchanged' }}">
+            <div class="audit-diff-block-label">
+                {{ (block.status ?? 'unchanged')|capitalize }}
+                {% if block.typeLabel ?? null %} · {{ block.typeLabel }}{% endif %}
+            </div>
+            {% if block.summary ?? null %}
+                <div class="audit-diff-block-summary">{{ block.summary }}</div>
+            {% endif %}
+            {% if block.fieldDiffs ?? [] is not empty %}
+                <details>
+                    <summary style="cursor:pointer;font-size:12px;opacity:0.7">
+                        {{ block.fieldDiffs|length }} field(s) changed
+                    </summary>
+                    {% for fieldDiff in block.fieldDiffs %}
+                        <div style="margin-top:4px">
+                            <strong>{{ fieldDiff.label ?? fieldDiff.handle ?? '' }}:</strong>
+                            {{ (fieldDiff.diff ?? '')|raw }}
+                        </div>
+                    {% endfor %}
+                </details>
+            {% endif %}
+        </div>
+    {% endfor %}
+</div>
+{% endif %}

--- a/src/templates/_diff/money.twig
+++ b/src/templates/_diff/money.twig
@@ -1,0 +1,23 @@
+{# _diff/money.twig — formatted currency with arrow. #}
+{% set from = change.from ?? null %}
+{% set to   = change.to   ?? null %}
+
+{% macro formatMoney(m) %}
+    {% if m is null %}
+        <em>None</em>
+    {% else %}
+        {% set amount = (m.amount ?? 0) / 100 %}
+        {% set currency = m.currency ?? 'USD' %}
+        {{ amount|number_format(2, '.', ',') }} {{ currency }}
+    {% endif %}
+{% endmacro %}
+
+{% if from == to %}
+    <span class="audit-diff-badge audit-diff-badge--identical">No changes</span>
+{% else %}
+<div class="audit-diff-simple">
+    <span class="audit-diff-old">{{ _self.formatMoney(from) }}</span>
+    <span class="audit-diff-arrow">→</span>
+    <span class="audit-diff-new">{{ _self.formatMoney(to) }}</span>
+</div>
+{% endif %}

--- a/src/templates/_diff/multi-option.twig
+++ b/src/templates/_diff/multi-option.twig
@@ -1,0 +1,28 @@
+{# _diff/multi-option.twig — pill tags: removed (red), kept (grey), added (green). #}
+{% set removed = change.removed ?? [] %}
+{% set added   = change.added   ?? [] %}
+{% set kept    = change.kept    ?? [] %}
+
+{% if removed is empty and added is empty %}
+    <span class="audit-diff-badge audit-diff-badge--identical">No changes</span>
+{% else %}
+<div class="audit-diff-pills">
+    {% for item in removed %}
+        <span class="audit-diff-pill audit-diff-pill--removed audit-tag-removed"
+              title="Removed: {{ item.value ?? item }}">
+            − {{ item.label ?? item.value ?? item }}
+        </span>
+    {% endfor %}
+    {% for item in kept %}
+        <span class="audit-diff-pill audit-diff-pill--kept">
+            {{ item.label ?? item.value ?? item }}
+        </span>
+    {% endfor %}
+    {% for item in added %}
+        <span class="audit-diff-pill audit-diff-pill--added audit-tag-added"
+              title="Added: {{ item.value ?? item }}">
+            + {{ item.label ?? item.value ?? item }}
+        </span>
+    {% endfor %}
+</div>
+{% endif %}

--- a/src/templates/_diff/neo.twig
+++ b/src/templates/_diff/neo.twig
@@ -1,0 +1,37 @@
+{# _diff/neo.twig — Neo blocks with nesting-level indentation. #}
+{% set blocks = change.blocks ?? [] %}
+
+{% if blocks is empty %}
+    <span class="audit-diff-badge audit-diff-badge--identical">No changes</span>
+{% else %}
+<div class="audit-diff-blocks">
+    {% for block in blocks %}
+        {% set level = block.level ?? 1 %}
+        <div class="audit-diff-block audit-diff-block--{{ block.status ?? 'unchanged' }}"
+             style="margin-left: {{ (level - 1) * 16 }}px;">
+            <div class="audit-diff-block-label">
+                {% if level > 1 %}{% for i in 1..(level - 1) %}└ {% endfor %}{% endif %}
+                {{ (block.status ?? 'unchanged')|capitalize }}
+                {% if block.typeLabel ?? null %} · {{ block.typeLabel }}{% endif %}
+                <small style="opacity:0.5">L{{ level }}</small>
+            </div>
+            {% if block.summary ?? null %}
+                <div class="audit-diff-block-summary">{{ block.summary }}</div>
+            {% endif %}
+            {% if block.fieldDiffs ?? [] is not empty %}
+                <details>
+                    <summary style="cursor:pointer;font-size:12px;opacity:0.7">
+                        {{ block.fieldDiffs|length }} field(s) changed
+                    </summary>
+                    {% for fieldDiff in block.fieldDiffs %}
+                        <div style="margin-top:4px">
+                            <strong>{{ fieldDiff.label ?? fieldDiff.handle ?? '' }}:</strong>
+                            {{ (fieldDiff.diff ?? '')|raw }}
+                        </div>
+                    {% endfor %}
+                </details>
+            {% endif %}
+        </div>
+    {% endfor %}
+</div>
+{% endif %}

--- a/src/templates/_diff/option.twig
+++ b/src/templates/_diff/option.twig
@@ -1,0 +1,15 @@
+{# _diff/option.twig — option labels with arrow. #}
+{% set from = change.from ?? '' %}
+{% set to   = change.to   ?? '' %}
+{% set fromLabel = change.fromLabel ?? from %}
+{% set toLabel   = change.toLabel   ?? to %}
+
+{% if from == to %}
+    <span class="audit-diff-badge audit-diff-badge--identical">No changes</span>
+{% else %}
+<div class="audit-diff-simple">
+    <span class="audit-diff-old" title="{{ from }}">{{ fromLabel }}</span>
+    <span class="audit-diff-arrow">→</span>
+    <span class="audit-diff-new" title="{{ to }}">{{ toLabel }}</span>
+</div>
+{% endif %}

--- a/src/templates/_diff/plain.twig
+++ b/src/templates/_diff/plain.twig
@@ -1,0 +1,17 @@
+{# _diff/plain.twig — "old → new" for short scalar values,
+   inline text diff for longer. #}
+{% set from = (change.from ?? '')|default('')|string %}
+{% set to   = (change.to   ?? '')|default('')|string %}
+{% set isShort = from|length < 80 and to|length < 80 %}
+
+{% if from == to %}
+    <span class="audit-diff-badge audit-diff-badge--identical">No changes</span>
+{% elseif isShort %}
+    <span class="audit-diff-simple">
+        <span class="audit-diff-old">{{ from }}</span>
+        <span class="audit-diff-arrow">→</span>
+        <span class="audit-diff-new">{{ to }}</span>
+    </span>
+{% else %}
+    {{ craft.audit.diff.renderTextDiff(from, to, 'inline', 'word')|raw }}
+{% endif %}

--- a/src/templates/_diff/relation.twig
+++ b/src/templates/_diff/relation.twig
@@ -1,0 +1,40 @@
+{# _diff/relation.twig — element chips with thumbnail + type. #}
+{% set removed = change.removed ?? [] %}
+{% set added   = change.added   ?? [] %}
+
+{% if removed is empty and added is empty %}
+    <span class="audit-diff-badge audit-diff-badge--identical">No changes</span>
+{% else %}
+<div class="audit-diff-relations">
+    {% for element in removed %}
+        <div class="audit-diff-relation-chip audit-chip audit-diff-relation-chip--removed">
+            {% if element.thumbUrl ?? null %}
+                <img class="audit-diff-relation-thumb" src="{{ element.thumbUrl }}" alt="">
+            {% endif %}
+            <span>{{ element.title ?? '(no title)' }}</span>
+            {% if element.type ?? null %}
+                <span class="audit-diff-relation-type">{{ element.type }}</span>
+            {% endif %}
+            {% if element.id ?? null %}
+                <small style="opacity:0.6">#{{ element.id }}</small>
+            {% endif %}
+            <span class="audit-diff-pill audit-diff-pill--removed audit-tag-removed" style="margin-left:auto">Removed</span>
+        </div>
+    {% endfor %}
+    {% for element in added %}
+        <div class="audit-diff-relation-chip audit-chip audit-diff-relation-chip--added">
+            {% if element.thumbUrl ?? null %}
+                <img class="audit-diff-relation-thumb" src="{{ element.thumbUrl }}" alt="">
+            {% endif %}
+            <span>{{ element.title ?? '(no title)' }}</span>
+            {% if element.type ?? null %}
+                <span class="audit-diff-relation-type">{{ element.type }}</span>
+            {% endif %}
+            {% if element.id ?? null %}
+                <small style="opacity:0.6">#{{ element.id }}</small>
+            {% endif %}
+            <span class="audit-diff-pill audit-diff-pill--added audit-tag-added" style="margin-left:auto">Added</span>
+        </div>
+    {% endfor %}
+</div>
+{% endif %}

--- a/src/templates/_diff/richtext.twig
+++ b/src/templates/_diff/richtext.twig
@@ -1,0 +1,17 @@
+{# _diff/richtext.twig — caxy HTML diff, collapsed if output >5KB. #}
+{% set from = (change.from ?? '')|default('') %}
+{% set to   = (change.to   ?? '')|default('') %}
+{% set diff = craft.audit.diff.renderHtmlDiff(from, to) %}
+{% set isLarge = diff|length > 5000 %}
+
+<div class="audit-diff-collapsible{% if isLarge %} audit-diff-collapsed{% endif %}"
+     data-collapsed="{{ isLarge ? 'true' : 'false' }}">
+    <div class="audit-diff-collapsible-content">
+        {{ diff|raw }}
+    </div>
+    {% if isLarge %}
+        <button type="button" class="audit-diff-collapsible-toggle" data-audit-diff-toggle>
+            Show full diff ({{ (diff|length / 1024)|round(1) }}KB)
+        </button>
+    {% endif %}
+</div>

--- a/src/templates/_diff/seo.twig
+++ b/src/templates/_diff/seo.twig
@@ -1,0 +1,32 @@
+{# _diff/seo.twig — SEO meta grid, only shows changed fields. #}
+{% set fields = change.fields ?? {} %}
+{% set seoFields = [
+    { key: 'title',              label: 'Title' },
+    { key: 'description',        label: 'Description' },
+    { key: 'keywords',           label: 'Keywords' },
+    { key: 'ogTitle',            label: 'OG Title' },
+    { key: 'ogDescription',      label: 'OG Description' },
+    { key: 'ogImage',            label: 'OG Image' },
+    { key: 'twitterTitle',       label: 'Twitter Title' },
+    { key: 'twitterDescription', label: 'Twitter Desc' }
+] %}
+
+{% set anyChanged = false %}
+{% for f in seoFields %}
+    {% if fields[f.key] is defined and (fields[f.key].changed ?? false) %}
+        {% set anyChanged = true %}
+    {% endif %}
+{% endfor %}
+
+{% if not anyChanged %}
+    <span class="audit-diff-badge audit-diff-badge--identical">No SEO changes</span>
+{% else %}
+    <div class="audit-diff-seo-grid">
+        {% for f in seoFields %}
+            {% if fields[f.key] is defined and (fields[f.key].changed ?? false) %}
+                <div class="audit-diff-seo-label">{{ f.label }}</div>
+                <div>{{ (fields[f.key].diff ?? '')|raw }}</div>
+            {% endif %}
+        {% endfor %}
+    </div>
+{% endif %}

--- a/src/templates/_diff/supertable.twig
+++ b/src/templates/_diff/supertable.twig
@@ -1,0 +1,32 @@
+{# _diff/supertable.twig — SuperTable rows (simpler — no types). #}
+{% set rows = change.rows ?? change.blocks ?? [] %}
+
+{% if rows is empty %}
+    <span class="audit-diff-badge audit-diff-badge--identical">No changes</span>
+{% else %}
+<div class="audit-diff-blocks">
+    {% for row in rows %}
+        <div class="audit-diff-block audit-diff-block--{{ row.status ?? 'unchanged' }}">
+            <div class="audit-diff-block-label">
+                {{ (row.status ?? 'unchanged')|capitalize }} · Row {{ (row.rowIndex ?? loop.index0) + 1 }}
+            </div>
+            {% if row.summary ?? null %}
+                <div class="audit-diff-block-summary">{{ row.summary }}</div>
+            {% endif %}
+            {% if row.fieldDiffs ?? [] is not empty %}
+                <details>
+                    <summary style="cursor:pointer;font-size:12px;opacity:0.7">
+                        {{ row.fieldDiffs|length }} field(s) changed
+                    </summary>
+                    {% for fieldDiff in row.fieldDiffs %}
+                        <div style="margin-top:4px">
+                            <strong>{{ fieldDiff.label ?? fieldDiff.handle ?? '' }}:</strong>
+                            {{ (fieldDiff.diff ?? '')|raw }}
+                        </div>
+                    {% endfor %}
+                </details>
+            {% endif %}
+        </div>
+    {% endfor %}
+</div>
+{% endif %}

--- a/src/templates/_diff/table.twig
+++ b/src/templates/_diff/table.twig
@@ -1,0 +1,37 @@
+{# _diff/table.twig — row-level diff with changed cells highlighted. #}
+{% set columns = change.columns ?? [] %}
+{% set rows    = change.rows    ?? [] %}
+
+{% if rows is empty %}
+    <span class="audit-diff-badge audit-diff-badge--identical">No changes</span>
+{% else %}
+<div class="audit-diff-table-wrap">
+    <table class="audit-diff-table">
+        <thead>
+            <tr>
+                {% for col in columns %}
+                    <th>{{ col.label ?? col.handle ?? col }}</th>
+                {% endfor %}
+            </tr>
+        </thead>
+        <tbody>
+            {% for row in rows %}
+                <tr class="row-{{ row.status ?? 'unchanged' }}">
+                    {% for col in columns %}
+                        {% set handle = col.handle ?? col %}
+                        {% set cell = (row.cells ?? {})[handle] ?? {} %}
+                        <td class="{{ cell.changed ?? false ? 'changed' : '' }}">
+                            {% if cell.changed ?? false %}
+                                <del>{{ cell.old ?? '' }}</del>
+                                <ins>{{ cell.new ?? '' }}</ins>
+                            {% else %}
+                                {{ cell.value ?? cell.new ?? cell.old ?? '' }}
+                            {% endif %}
+                        </td>
+                    {% endfor %}
+                </tr>
+            {% endfor %}
+        </tbody>
+    </table>
+</div>
+{% endif %}

--- a/src/templates/_diff/truncated.twig
+++ b/src/templates/_diff/truncated.twig
@@ -1,0 +1,14 @@
+{# _diff/truncated.twig — field too large, shown truncated. #}
+<div class="audit-diff-truncated">
+    <strong>✂ Content truncated</strong>
+    {% if change.reason ?? null %}
+        — {{ change.reason }}
+    {% elseif change.size ?? null %}
+        — {{ change.size }} bytes (limit exceeded)
+    {% else %}
+        — value exceeded the diff size limit
+    {% endif %}
+    {% if change.preview ?? null %}
+        <pre style="margin-top:6px;font-size:11px;opacity:0.7;white-space:pre-wrap">{{ change.preview }}</pre>
+    {% endif %}
+</div>

--- a/src/templates/_diff/vizy.twig
+++ b/src/templates/_diff/vizy.twig
@@ -1,0 +1,37 @@
+{# _diff/vizy.twig — caxy diff for text nodes + block summary for Vizy blocks. #}
+{% set from = change.from ?? '' %}
+{% set to   = change.to   ?? '' %}
+{% set blocks = change.blocks ?? [] %}
+{% set textDiff = change.textDiff ?? null %}
+
+{% if textDiff is null and (from or to) %}
+    {% set textDiff = craft.audit.diff.renderHtmlDiff(from, to) %}
+{% endif %}
+
+{% set hasText = textDiff and textDiff matches '/<(ins|del)/' %}
+
+{% if textDiff and hasText %}
+    <div class="audit-diff-html" style="margin-bottom: 8px;">
+        {{ textDiff|raw }}
+    </div>
+{% endif %}
+
+{% if blocks is not empty %}
+    <div class="audit-diff-blocks">
+        {% for block in blocks %}
+            <div class="audit-diff-block audit-diff-block--{{ block.status ?? 'unchanged' }}">
+                <div class="audit-diff-block-label">
+                    {{ (block.status ?? 'unchanged')|capitalize }}
+                    {% if block.typeLabel ?? null %} · {{ block.typeLabel }}{% endif %}
+                </div>
+                {% if block.summary ?? null %}
+                    <div class="audit-diff-block-summary">{{ block.summary }}</div>
+                {% endif %}
+            </div>
+        {% endfor %}
+    </div>
+{% endif %}
+
+{% if not hasText and blocks is empty %}
+    <span class="audit-diff-badge audit-diff-badge--identical">No changes</span>
+{% endif %}

--- a/src/variables/AuditVariable.php
+++ b/src/variables/AuditVariable.php
@@ -13,6 +13,7 @@ namespace superbig\audit\variables;
 use craft\base\Component;
 
 use superbig\audit\Audit;
+use superbig\audit\services\DiffRenderer;
 
 /**
  * @author    Superbig
@@ -29,5 +30,23 @@ class AuditVariable extends Component
     public function getLocationInfoForIp($ipAddress = null)
     {
         return Audit::$plugin->geo->getLocationInfoForIp($ipAddress);
+    }
+
+    /**
+     * Expose the DiffRenderer service to Twig.
+     *
+     * Usage: {{ craft.audit.diff.renderHtmlDiff(from, to)|raw }}
+     */
+    public function getDiff(): DiffRenderer
+    {
+        return Audit::$plugin->diffRenderer;
+    }
+
+    /**
+     * Alias so both {{ craft.audit.diff }} and {{ craft.audit.diff() }} work.
+     */
+    public function diff(): DiffRenderer
+    {
+        return Audit::$plugin->diffRenderer;
     }
 }

--- a/src/web/assets/diff/AuditDiffAsset.php
+++ b/src/web/assets/diff/AuditDiffAsset.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace superbig\audit\web\assets\diff;
+
+use craft\web\AssetBundle;
+use craft\web\assets\cp\CpAsset;
+
+/**
+ * AuditDiffAsset — CSS bundle for rendering diffs in the Craft Audit CP.
+ *
+ * Namespaced under .audit-diff-* classes to avoid CP conflicts.
+ * Provides light + dark-mode styles via CSS custom properties.
+ */
+class AuditDiffAsset extends AssetBundle
+{
+    public function init(): void
+    {
+        $this->sourcePath = '@superbig/audit/web/assets/diff/dist';
+        $this->depends = [CpAsset::class];
+        $this->css = ['diff.css'];
+        parent::init();
+    }
+}

--- a/src/web/assets/diff/dist/diff.css
+++ b/src/web/assets/diff/dist/diff.css
@@ -1,0 +1,536 @@
+/* ═══════════════════════════════════════════════════════════════════
+   Craft Audit Plugin — Diff Styles
+   Namespaced under .audit-diff to avoid Craft CP conflicts.
+   Supports both light and dark mode.
+   ═══════════════════════════════════════════════════════════════════ */
+
+/* ── CSS Custom Properties (light mode defaults) ─────────────────── */
+:root {
+    --audit-diff-del-bg:        #fbe1e1;
+    --audit-diff-ins-bg:        #e1fbe1;
+    --audit-diff-rep-bg:        #fef6d9;
+    --audit-diff-del-inline:    #f09494;
+    --audit-diff-ins-inline:    #94f094;
+    --audit-diff-border:        #d0d0d0;
+    --audit-diff-gutter-bg:     #f5f5f5;
+    --audit-diff-cell-bg:       #ffffff;
+    --audit-diff-text:          #333333;
+    --audit-diff-font:          'SFMono-Regular', Consolas, 'Liberation Mono', Menlo, monospace;
+    --audit-diff-font-size:     12px;
+    --audit-diff-badge-eq-bg:   #f0f0f0;
+    --audit-diff-badge-eq-text: #666;
+    --audit-diff-badge-err-bg:  #fff3cd;
+    --audit-diff-badge-err-text:#856404;
+}
+
+/* Dark mode via media query */
+@media (prefers-color-scheme: dark) {
+    :root {
+        --audit-diff-del-bg:        #3d1a1a;
+        --audit-diff-ins-bg:        #1a3d1a;
+        --audit-diff-rep-bg:        #3d3510;
+        --audit-diff-del-inline:    #c0392b;
+        --audit-diff-ins-inline:    #27ae60;
+        --audit-diff-border:        #444444;
+        --audit-diff-gutter-bg:     #2a2a2a;
+        --audit-diff-cell-bg:       #1e1e1e;
+        --audit-diff-text:          #e0e0e0;
+        --audit-diff-badge-eq-bg:   #2a2a2a;
+        --audit-diff-badge-eq-text: #aaa;
+        --audit-diff-badge-err-bg:  #3d2e00;
+        --audit-diff-badge-err-text:#ffc107;
+    }
+}
+
+/* Dark mode via Craft CP .dark body class (user preference override) */
+body.dark {
+    --audit-diff-del-bg:        #3d1a1a;
+    --audit-diff-ins-bg:        #1a3d1a;
+    --audit-diff-rep-bg:        #3d3510;
+    --audit-diff-del-inline:    #c0392b;
+    --audit-diff-ins-inline:    #27ae60;
+    --audit-diff-border:        #444444;
+    --audit-diff-gutter-bg:     #2a2a2a;
+    --audit-diff-cell-bg:       #1e1e1e;
+    --audit-diff-text:          #e0e0e0;
+    --audit-diff-badge-eq-bg:   #2a2a2a;
+    --audit-diff-badge-eq-text: #aaa;
+    --audit-diff-badge-err-bg:  #3d2e00;
+    --audit-diff-badge-err-text:#ffc107;
+}
+
+/* ── jfcherng/php-diff table styles ─────────────────────────────── */
+
+table.audit-diff.diff-wrapper {
+    border-collapse: collapse;
+    border-spacing: 0;
+    border: 1px solid var(--audit-diff-border);
+    color: var(--audit-diff-text);
+    font-family: var(--audit-diff-font);
+    font-size: var(--audit-diff-font-size);
+    width: 100%;
+    word-break: break-word;
+    background: var(--audit-diff-cell-bg);
+    border-radius: 4px;
+    overflow: hidden;
+}
+
+table.audit-diff.diff-wrapper th,
+table.audit-diff.diff-wrapper td {
+    border: none;
+    padding: 2px 6px;
+    background: var(--audit-diff-cell-bg);
+    color: var(--audit-diff-text);
+    vertical-align: baseline;
+}
+
+table.audit-diff.diff-wrapper tbody th {
+    background: var(--audit-diff-gutter-bg);
+    border-right: 1px solid var(--audit-diff-border);
+    color: var(--audit-diff-text);
+    opacity: 0.6;
+    text-align: right;
+    vertical-align: top;
+    width: 3em;
+    font-size: 11px;
+    user-select: none;
+}
+
+table.audit-diff.diff-wrapper tbody th.sign {
+    background: var(--audit-diff-cell-bg);
+    border-right: none;
+    width: 1.2em;
+    text-align: center;
+}
+table.audit-diff.diff-wrapper tbody th.sign.del { background: var(--audit-diff-del-bg); }
+table.audit-diff.diff-wrapper tbody th.sign.ins { background: var(--audit-diff-ins-bg); }
+
+table.audit-diff.diff-wrapper.diff-html .change .old { background: var(--audit-diff-del-bg); }
+table.audit-diff.diff-wrapper.diff-html .change .new { background: var(--audit-diff-ins-bg); }
+table.audit-diff.diff-wrapper.diff-html .change .rep { background: var(--audit-diff-rep-bg); }
+
+table.audit-diff.diff-wrapper.diff-html .change .old.none,
+table.audit-diff.diff-wrapper.diff-html .change .new.none,
+table.audit-diff.diff-wrapper.diff-html .change .rep.none {
+    background: transparent;
+    cursor: not-allowed;
+}
+
+table.audit-diff.diff-wrapper.diff-html .change ins {
+    background: var(--audit-diff-ins-inline);
+    text-decoration: none;
+    font-weight: 600;
+    border-radius: 2px;
+    padding: 0 1px;
+}
+table.audit-diff.diff-wrapper.diff-html .change del {
+    background: var(--audit-diff-del-inline);
+    text-decoration: none;
+    font-weight: 600;
+    border-radius: 2px;
+    padding: 0 1px;
+}
+
+table.audit-diff.diff-wrapper tbody.skipped {
+    border-top: 1px dashed var(--audit-diff-border);
+}
+table.audit-diff.diff-wrapper tbody.skipped td,
+table.audit-diff.diff-wrapper tbody.skipped th {
+    display: none;
+}
+
+/* ── caxy/php-htmldiff styles ────────────────────────────────────── */
+
+.audit-diff-html {
+    font-size: 14px;
+    line-height: 1.6;
+    color: var(--audit-diff-text);
+}
+
+.audit-diff-html ins,
+.audit-diff-html ins.diffins,
+.audit-diff-html ins.diffmod {
+    background: var(--audit-diff-ins-bg);
+    color: var(--audit-diff-text);
+    text-decoration: none;
+    border-radius: 2px;
+    padding: 0 2px;
+}
+
+.audit-diff-html del,
+.audit-diff-html del.diffmod {
+    background: var(--audit-diff-del-bg);
+    color: var(--audit-diff-text);
+    text-decoration: line-through;
+    border-radius: 2px;
+    padding: 0 2px;
+    opacity: 0.8;
+}
+
+.audit-diff-html table ins,
+.audit-diff-html table del {
+    display: block;
+}
+
+/* ── Simple diff (renderSimpleDiff) ──────────────────────────────── */
+
+.audit-diff-simple {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    font-size: 13px;
+    flex-wrap: wrap;
+}
+
+.audit-diff-simple .audit-diff-old {
+    color: #c0392b;
+    text-decoration: line-through;
+    opacity: 0.8;
+}
+
+.audit-diff-simple .audit-diff-new {
+    color: #27ae60;
+    font-weight: 500;
+}
+
+.audit-diff-simple .audit-diff-arrow {
+    color: #999;
+    font-size: 11px;
+}
+
+body.dark .audit-diff-simple .audit-diff-old { color: #e57373; }
+body.dark .audit-diff-simple .audit-diff-new { color: #7dcea0; }
+
+/* ── Status badges ───────────────────────────────────────────────── */
+
+.audit-diff-badge {
+    display: inline-block;
+    padding: 2px 8px;
+    border-radius: 10px;
+    font-size: 11px;
+    font-weight: 500;
+    letter-spacing: 0.02em;
+}
+
+.audit-diff-badge--identical {
+    background: var(--audit-diff-badge-eq-bg);
+    color: var(--audit-diff-badge-eq-text);
+}
+
+.audit-diff-badge--error {
+    background: var(--audit-diff-badge-err-bg);
+    color: var(--audit-diff-badge-err-text);
+}
+
+/* ── Boolean badges ──────────────────────────────────────────────── */
+
+.audit-diff-bool {
+    display: inline-flex;
+    align-items: center;
+    gap: 8px;
+}
+
+.audit-diff-bool-badge {
+    display: inline-flex;
+    align-items: center;
+    gap: 4px;
+    padding: 3px 10px;
+    border-radius: 12px;
+    font-size: 12px;
+    font-weight: 600;
+}
+
+.audit-diff-bool-badge--on  { background: #d4edda; color: #155724; }
+.audit-diff-bool-badge--off { background: #f8d7da; color: #721c24; }
+
+body.dark .audit-diff-bool-badge--on  { background: #1a3d1a; color: #7dcea0; }
+body.dark .audit-diff-bool-badge--off { background: #3d1a1a; color: #e57373; }
+
+/* ── Color swatch ────────────────────────────────────────────────── */
+
+.audit-diff-color {
+    display: inline-flex;
+    align-items: center;
+    gap: 8px;
+}
+
+.audit-diff-color-side {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+}
+
+.audit-diff-color-swatch,
+.audit-color-swatch {
+    width: 20px;
+    height: 20px;
+    border-radius: 4px;
+    border: 1px solid rgba(0,0,0,0.15);
+    display: inline-block;
+    flex-shrink: 0;
+}
+
+/* ── Tag pills (multi-option) ────────────────────────────────────── */
+
+.audit-diff-pills {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 4px;
+    align-items: center;
+}
+
+.audit-diff-pill,
+.audit-tag-added,
+.audit-tag-removed {
+    display: inline-block;
+    padding: 2px 8px;
+    border-radius: 10px;
+    font-size: 12px;
+    font-weight: 500;
+}
+
+.audit-diff-pill--removed,
+.audit-tag-removed { background: #fbe1e1; color: #c0392b; }
+.audit-diff-pill--added,
+.audit-tag-added   { background: #e1fbe1; color: #27ae60; }
+.audit-diff-pill--kept    { background: #f0f0f0; color: #555; }
+
+body.dark .audit-diff-pill--removed,
+body.dark .audit-tag-removed { background: #3d1a1a; color: #e57373; }
+body.dark .audit-diff-pill--added,
+body.dark .audit-tag-added   { background: #1a3d1a; color: #7dcea0; }
+body.dark .audit-diff-pill--kept { background: #2a2a2a; color: #aaa; }
+
+/* ── Element chips (relation) ────────────────────────────────────── */
+
+.audit-diff-relations {
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+}
+
+.audit-diff-relation-chip,
+.audit-chip {
+    display: inline-flex;
+    align-items: center;
+    gap: 8px;
+    padding: 4px 8px;
+    border-radius: 6px;
+    font-size: 13px;
+    border: 1px solid var(--audit-diff-border);
+    background: var(--audit-diff-cell-bg);
+}
+
+.audit-diff-relation-chip--removed { border-color: #f09494; background: #fbe1e1; }
+.audit-diff-relation-chip--added   { border-color: #94f094; background: #e1fbe1; }
+
+body.dark .audit-diff-relation-chip--removed { border-color: #c0392b; background: #3d1a1a; }
+body.dark .audit-diff-relation-chip--added   { border-color: #27ae60; background: #1a3d1a; }
+
+.audit-diff-relation-thumb {
+    width: 24px;
+    height: 24px;
+    border-radius: 3px;
+    object-fit: cover;
+}
+
+.audit-diff-relation-type {
+    font-size: 10px;
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+    opacity: 0.6;
+    padding: 1px 4px;
+    border-radius: 3px;
+    background: var(--audit-diff-gutter-bg);
+}
+
+/* ── Collapsible rich text ───────────────────────────────────────── */
+
+.audit-diff-collapsible {
+    position: relative;
+}
+
+.audit-diff-collapsible[data-collapsed="true"] .audit-diff-collapsible-content,
+.audit-diff-collapsed .audit-diff-collapsible-content {
+    max-height: 120px;
+    overflow: hidden;
+}
+
+.audit-diff-collapsible[data-collapsed="true"]::after,
+.audit-diff-collapsed::after {
+    content: '';
+    position: absolute;
+    bottom: 0;
+    left: 0;
+    right: 0;
+    height: 40px;
+    background: linear-gradient(transparent, var(--audit-diff-cell-bg));
+    pointer-events: none;
+}
+
+.audit-diff-collapsible-toggle {
+    display: block;
+    margin-top: 4px;
+    font-size: 12px;
+    color: #0d6efd;
+    cursor: pointer;
+    background: none;
+    border: none;
+    padding: 0;
+}
+
+/* ── Matrix/Neo/SuperTable block summary ─────────────────────────── */
+
+.audit-diff-blocks {
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+}
+
+.audit-diff-block {
+    padding: 6px 10px;
+    border-radius: 6px;
+    border-left: 3px solid transparent;
+    font-size: 13px;
+}
+
+.audit-diff-block--added   { border-color: #27ae60; background: #e1fbe1; }
+.audit-diff-block--removed { border-color: #c0392b; background: #fbe1e1; }
+.audit-diff-block--changed { border-color: #f39c12; background: #fef6d9; }
+.audit-diff-block--unchanged { border-color: #ccc; background: #f9f9f9; opacity: 0.7; }
+
+body.dark .audit-diff-block--added    { background: #1a3d1a; }
+body.dark .audit-diff-block--removed  { background: #3d1a1a; }
+body.dark .audit-diff-block--changed  { background: #3d3510; }
+body.dark .audit-diff-block--unchanged { background: #2a2a2a; }
+
+.audit-diff-block-label {
+    font-weight: 600;
+    font-size: 11px;
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+    opacity: 0.7;
+    margin-bottom: 2px;
+}
+
+.audit-diff-block-summary {
+    font-size: 13px;
+    opacity: 0.85;
+}
+
+/* ── Table field diff ────────────────────────────────────────────── */
+
+.audit-diff-table-wrap {
+    overflow-x: auto;
+}
+
+.audit-diff-table {
+    border-collapse: collapse;
+    width: 100%;
+    font-size: 13px;
+}
+
+.audit-diff-table th,
+.audit-diff-table td {
+    border: 1px solid var(--audit-diff-border);
+    padding: 4px 8px;
+    text-align: left;
+}
+
+.audit-diff-table th {
+    background: var(--audit-diff-gutter-bg);
+    font-weight: 600;
+    font-size: 11px;
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+}
+
+.audit-diff-table td.changed { background: var(--audit-diff-rep-bg); }
+.audit-diff-table tr.row-added   td { background: var(--audit-diff-ins-bg); }
+.audit-diff-table tr.row-removed td { background: var(--audit-diff-del-bg); }
+
+/* ── SEO meta grid ───────────────────────────────────────────────── */
+
+.audit-diff-seo-grid {
+    display: grid;
+    grid-template-columns: auto 1fr;
+    gap: 4px 12px;
+    font-size: 13px;
+}
+
+.audit-diff-seo-label {
+    font-weight: 600;
+    color: #666;
+    white-space: nowrap;
+    padding-top: 2px;
+}
+
+body.dark .audit-diff-seo-label { color: #aaa; }
+
+/* ── Generic / config / truncated / error ────────────────────────── */
+
+.audit-diff-generic {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 8px;
+    font-family: var(--audit-diff-font);
+    font-size: 12px;
+}
+
+.audit-diff-generic-side {
+    padding: 6px 8px;
+    border: 1px solid var(--audit-diff-border);
+    border-radius: 4px;
+    background: var(--audit-diff-cell-bg);
+    overflow-x: auto;
+}
+
+.audit-diff-generic-side.old { border-left: 3px solid #c0392b; }
+.audit-diff-generic-side.new { border-left: 3px solid #27ae60; }
+
+.audit-diff-generic-label {
+    font-weight: 600;
+    font-size: 10px;
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+    opacity: 0.6;
+    margin-bottom: 4px;
+}
+
+.audit-diff-config-row {
+    display: grid;
+    grid-template-columns: 200px 1fr;
+    gap: 8px;
+    padding: 4px 0;
+    border-bottom: 1px solid var(--audit-diff-border);
+    font-size: 13px;
+}
+
+.audit-diff-config-row:last-child {
+    border-bottom: none;
+}
+
+.audit-diff-config-key {
+    font-family: var(--audit-diff-font);
+    font-size: 12px;
+    opacity: 0.8;
+    word-break: break-all;
+}
+
+.audit-diff-error {
+    padding: 8px 12px;
+    border-radius: 4px;
+    background: var(--audit-diff-badge-err-bg);
+    color: var(--audit-diff-badge-err-text);
+    font-size: 13px;
+}
+
+.audit-diff-truncated {
+    padding: 8px 12px;
+    border-radius: 4px;
+    background: var(--audit-diff-gutter-bg);
+    color: var(--audit-diff-text);
+    font-size: 12px;
+    font-style: italic;
+    opacity: 0.85;
+}

--- a/tests/Unit/DiffRendererTest.php
+++ b/tests/Unit/DiffRendererTest.php
@@ -1,0 +1,100 @@
+<?php
+
+use superbig\audit\Audit;
+use superbig\audit\services\DiffRenderer;
+
+it('exposes DiffRenderer as a registered component', function () {
+    $r = Audit::$plugin->diffRenderer;
+    expect($r)->toBeInstanceOf(DiffRenderer::class);
+});
+
+it('renders identical strings as a "No changes" badge', function () {
+    $r = Audit::$plugin->diffRenderer;
+    $out = $r->renderTextDiff('same', 'same');
+    expect($out)->toContain('No changes');
+});
+
+it('renders a text diff with ins/del markup for differing strings', function () {
+    $r = Audit::$plugin->diffRenderer;
+    $out = $r->renderTextDiff('Hello world', 'Hello everyone');
+    $hasMarkup = str_contains($out, 'ins') || str_contains($out, 'del');
+    expect($hasMarkup)->toBeTrue();
+});
+
+it('renders HTML diff and preserves ins markup', function () {
+    $r = Audit::$plugin->diffRenderer;
+    $out = $r->renderHtmlDiff('<p>Hello</p>', '<p>Hello world</p>');
+    // Either contains <ins or falls back to simple diff; either way non-empty & marks the change
+    expect($out)->not->toBeEmpty();
+    $marks = str_contains($out, 'ins') || str_contains($out, 'audit-diff-new');
+    expect($marks)->toBeTrue();
+});
+
+it('handles empty old value', function () {
+    $r = Audit::$plugin->diffRenderer;
+    $out = $r->renderTextDiff('', 'New content');
+    expect($out)->not->toBeEmpty();
+});
+
+it('handles empty new value', function () {
+    $r = Audit::$plugin->diffRenderer;
+    $out = $r->renderTextDiff('Old content', '');
+    expect($out)->not->toBeEmpty();
+});
+
+it('treats both-empty as identical', function () {
+    $r = Audit::$plugin->diffRenderer;
+    $out = $r->renderTextDiff('', '');
+    expect($out)->toContain('No changes');
+});
+
+it('truncates content over maxBytes', function () {
+    $r = Audit::$plugin->diffRenderer;
+    $huge = str_repeat('x', 100000);
+    $out = $r->maybeTruncate($huge, 1000);
+    expect(strlen($out))->toBeLessThan(1200); // truncated + marker
+    expect($out)->toContain('truncated');
+});
+
+it('returns original content when under maxBytes', function () {
+    $r = Audit::$plugin->diffRenderer;
+    $small = 'hello';
+    expect($r->maybeTruncate($small, 1000))->toBe('hello');
+});
+
+it('renders a simple "old → new" diff for scalar values', function () {
+    $r = Audit::$plugin->diffRenderer;
+    $out = $r->renderSimpleDiff('on', 'off');
+    expect($out)->toContain('on');
+    expect($out)->toContain('off');
+    expect($out)->toContain('audit-diff-simple');
+});
+
+it('escapes HTML in simple diff to prevent XSS', function () {
+    $r = Audit::$plugin->diffRenderer;
+    $out = $r->renderSimpleDiff('<script>alert(1)</script>', 'safe');
+    expect($out)->not->toContain('<script>alert(1)</script>');
+    expect($out)->toContain('&lt;script');
+});
+
+it('renders json diff for structured data', function () {
+    $r = Audit::$plugin->diffRenderer;
+    $out = $r->renderJsonDiff(['a' => 1], ['a' => 2]);
+    expect($out)->not->toBeEmpty();
+    expect($out)->not->toContain('No changes');
+});
+
+it('returns identical for equal json', function () {
+    $r = Audit::$plugin->diffRenderer;
+    $out = $r->renderJsonDiff(['x' => 1, 'y' => 2], ['x' => 1, 'y' => 2]);
+    expect($out)->toContain('No changes');
+});
+
+it('gracefully handles malformed HTML without throwing', function () {
+    $r = Audit::$plugin->diffRenderer;
+    $malformed = '<p><p><p>unclosed tags<script>';
+    $closure = fn() => $r->renderHtmlDiff($malformed, '');
+    expect($closure)->not->toThrow(\Throwable::class);
+    // Must still return a non-empty string
+    expect($closure())->toBeString()->not->toBeEmpty();
+});


### PR DESCRIPTION
- Add DiffRenderer service wrapping jfcherng/php-diff + caxy/php-htmldiff
- Register diffRenderer component + expose via craft.audit.diff in Twig
- AuditDiffAsset bundle + diff.css (namespaced, dark-mode via CSS custom
  properties and both media-query + body.dark selectors)
- 20 per-handler Twig templates under src/templates/_diff/:
  index (dispatcher), plain, color, richtext, date, boolean, option,
  multi-option, relation, money, table, matrix, neo, supertable, vizy,
  seo, generic, config, error, truncated
- Register asset bundle on audit/index and audit/details actions
- 14 DiffRendererTest cases (truncation, identical, empty, HTML/text/JSON,
  XSS escape, malformed HTML fallback)
- Tests: 114 passed, 1 skipped (was 100 passed) — +14