### PR TITLE
Phase 3.0 — Docs: ship escape hatch (filter-records + getting-started + events-and-recording)

### DIFF
--- a/docs/concepts/events-and-recording.md
+++ b/docs/concepts/events-and-recording.md
@@ -1,0 +1,108 @@
+# Events and recording
+
+Audit records events. That's a short sentence and it hides everything a serious user wants to know.
+
+When *exactly* does Audit fire a record? What's actually in a "record"? Can you intercept one before it writes? Does the plugin batch, or is every save a row? These aren't edge-case questions — they're the first questions from anyone planning to extend the plugin, filter its output, or route records to another system.
+
+This page walks through the recording pipeline: from the Craft event that triggers a write, through the handler that builds the model, to the row in `audit_log`. It's a conceptual view — no tasks, no recipes. Use it to orient yourself, then jump to a how-to or reference when you need to do something.
+
+## The recording pipeline
+
+Every audit row travels the same path, regardless of whether it started as an entry save, a user login, or a project config change:
+
+```
+Craft event fires
+    (Element::EVENT_AFTER_SAVE, User::EVENT_AFTER_LOGIN,
+     ProjectConfig onAdd, etc.)
+        ↓
+Audit handler receives it
+    (ElementHandler, UserHandler, SchemaHandler, ...)
+        ↓
+Handler builds an AuditModel
+    (actor, timestamp, request context, snapshot, changed fields)
+        ↓
+AuditRecorder::record() is called
+        ↓
+BeforeRecordEvent fires
+    (your chance to cancel or mutate)
+        ↓
+If not cancelled, AuditRecord is persisted to audit_log
+```
+
+Each step has a specific job.
+
+**The Craft event** is whatever signal Craft itself emits: `Elements::EVENT_AFTER_SAVE_ELEMENT`, `User::EVENT_AFTER_LOGIN`, `Fields::EVENT_AFTER_SAVE_FIELD`, and so on. For config areas where Craft has no PHP event (filesystems, image transforms, volumes, sites, category groups, tag groups, global sets), Audit listens on project config paths directly — `onAdd`, `onUpdate`, `onRemove`.
+
+**The Audit handler** is one of eight small services under `src/services/handlers/` — `ElementHandler`, `UserHandler`, `UserGroupHandler`, `SchemaHandler`, `RouteHandler`, `BackupHandler`, `PluginHandler`, `SettingsHandler`. Each one owns a thin slice of Craft's event surface. It decides whether the event is worth recording (skipping propagation saves, revisions, disabled event types), extracts what matters from the payload, and builds an `AuditModel`.
+
+**`AuditRecorder::record()`** is the single entry point for persistence. Every handler eventually calls it. It hydrates the request context (user, session, site, IP, user agent), detects the request source (`cp`, `site`, `console`, `yaml`), fires `BeforeRecordEvent`, and — if the event wasn't cancelled — writes one row to `audit_log`.
+
+**`BeforeRecordEvent`** is the extension seam. It runs on every record, carries the fully-built `AuditModel`, and is cancellable. This is where user code filters, mutates, or tags records. See [how to filter records](../how-to/filter-records.md) for recipes.
+
+**The write** is a single INSERT into `audit_log`. Failures are warned, not thrown — a broken audit insert doesn't crash the request that triggered it.
+
+## What gets captured
+
+Every row in `audit_log` has the same four groups of data. This is what makes Audit more than a line in the Craft log.
+
+**Actor.** Who did it. `userId`, `sessionId`, and `dateCreated`. The `users` FK uses `SET NULL` on delete, so deleting a user doesn't orphan their audit trail — the record survives with `userId = NULL` and whatever context it captured at write time.
+
+**Request context.** Where and how it happened. `ip`, `userAgent`, `location` (JSON-encoded GeoIP payload, when MaxMind credentials are configured), and `request` — one of `cp`, `site`, `console`, or `yaml`. This is the block that separates Audit from the Craft log. The Craft log tells you `webuser` saved an entry. Audit tells you `webuser` saved an entry from `94.228.41.12` in Oslo via a console job.
+
+**Subject.** What changed. `elementId`, `elementType`, `event` (the kebab-case string, e.g. `entry-saved`), `title` (human-readable label), and `parentId` for grouped records — currently used by the `ResaveElements` job to collapse thousands of children under one summary row.
+
+**Snapshot and changed fields.** The payload. `snapshot` is the full element state as JSON, built by the relevant handler. For entry saves, the snapshot includes `content` (Craft's `getSerializedFieldValues()` output), `sectionName`, `elementTypeLabel`, and a title. For project config events, it includes the config path and the raw `newValue`/`oldValue`. `changedFields` is a per-field diff, produced by `FieldDiffService` from the registered field handlers — what changed, handler-typed, rendered later by `DiffRenderer`.
+
+All four groups are set on the `AuditModel` before `BeforeRecordEvent` fires. Your listener sees the full row, not a stub.
+
+## When a record is (and isn't) fired
+
+This is the question support tickets keep asking. The short version:
+
+### Fired
+
+- **Element saves and deletes** — entries, categories, assets, users, globals, and any other element type Craft emits `EVENT_AFTER_SAVE_ELEMENT` for.
+- **User lifecycle** — login, logout, activate, deactivate, suspend, unsuspend, lock, unlock, and group assignment.
+- **Permission changes** — per user and per group. User groups created, saved, and deleted.
+- **Schema changes** — fields, sections, and entry types (create, save, delete).
+- **Project config changes** — filesystems, volumes, image transforms, sites, site groups, category groups, tag groups, and global sets. Audit listens via `ProjectConfig::onAdd`, `onUpdate`, and `onRemove` because Craft doesn't emit PHP events for these areas directly.
+- **Settings changes** — system settings and email settings, via `ProjectConfig::EVENT_UPDATE_ITEM` scoped to `system.*` and `email.*` paths.
+- **Plugin lifecycle** — install, uninstall, enable, disable.
+- **Routes** — saves and deletes of routes defined in the control panel.
+- **Database backups** — created and restored.
+
+### Not fired
+
+- **Element propagation saves.** Audit detects these via `$element->propagating` and skips. A multi-site entry save emits one save per site; only the initial one is recorded.
+- **Resave-job children.** `$element->resaving` is also short-circuited in `ElementHandler::onSaveElement()`. The parent `ResaveElements` job gets one summary row via `onBeforeResave` / `onResaveEnd`; the individual element saves are skipped. Feed Me is a different story — see the roadmap below.
+- **Revisions.** `ElementHelper::rootElement()` walks to the canonical element. If it's a revision, Audit returns early — revisions are Craft's immutable history, separately addressable.
+- **Drafts.** Skipped by default. Enable `logDraftEvents` in plugin settings if you need them.
+- **Child elements.** Matrix blocks, Neo blocks, and other nested elements. Audit records the root save (the parent entry), and the child content lands inside its `snapshot.content`. You don't get a separate row per block. Enable `logChildElementEvents` if you want per-child rows.
+- **Anything Craft doesn't emit.** There's no PHP event for it and no project config path for it? Audit doesn't see it.
+
+The "not fired" list is explicit because "why isn't X in my audit log?" is a recurring question. Most of the time the answer is in that list.
+
+## Customization points
+
+Four hooks cover most extension needs. Each one is documented on its own page.
+
+- **Cancel or mutate records before they save.** Use `BeforeRecordEvent`. Fires on every record, carries the full model, cancellable. See [how to filter records](../how-to/filter-records.md).
+- **Register a field handler for a custom field type.** Listen for `FieldHandlerRegistry::EVENT_REGISTER_HANDLERS` and add your handler class to `$event->handlers`. See `docs/how-to/handle-custom-fields.md` (lands in P3.2).
+- **Record your own events from a third-party plugin.** Call `Audit::$plugin->auditRecorder->record()` directly. The first argument is an `AuditEvent` enum case or a string; the backing strings match the legacy `AuditModel::EVENT_*` constants, so anything written against v2 keeps working. See `docs/how-to/record-custom-events.md` (lands in P3.2).
+- **Query or export records.** The `audit_log` table is indexed on `(dateCreated, event)`, `(userId, dateCreated)`, and the individual columns `userId`, `elementId`, `sessionId`, `parentId`, `dateCreated`, `siteId`, and `event`. Use standard Craft query builder or raw SQL. See `docs/reference/services.md` (lands in P3.1).
+
+## What's on the roadmap (and what it means for you)
+
+Audit records every write individually. That's the right default for compliance, and the wrong default for operators who run nightly imports. The plugin's known gaps — and the work planned to close them — are worth knowing about now.
+
+**Batch grouping.** Today, only `ResaveElements` gets batch treatment (one parent summary row, child rows with `parent_id` set). Feed Me, custom import scripts, and plugin-driven save loops produce one row per element. The plan is a first-class `EVENT_BATCH_STARTED` / `EVENT_BATCH_ENDED` API plus a generalized `parent_id` mechanism, so any code path — your own imports included — can bracket a batch and collapse its output in the UI. Tracking in the [batch-processing analysis](../../analysis/batch-processing-strategies.md); in progress.
+
+**Queue-backed recording.** Currently the audit write is synchronous — every save blocks on the INSERT. For high-volume installs that's a noticeable tax on response time. A queue-backed mode is planned: `AuditRecorder::record()` would build the model, fire `BeforeRecordEvent`, and push a job instead of writing directly. Fidelity preserved, response time reclaimed. Planned, not in flight.
+
+Until both ship, the interim workaround for batch noise is `BeforeRecordEvent`. It's not as clean as grouping — the listener still runs per record — but it's the escape hatch available today. See [how to filter records](../how-to/filter-records.md).
+
+## Related
+
+- [How to filter records](../how-to/filter-records.md) — drop, transform, or tag records with `BeforeRecordEvent`.
+- `docs/reference/events.md` — every event type, with example payloads. Lands in P3.1.
+- [Batch processing strategies](../../analysis/batch-processing-strategies.md) — the roadmap in detail.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -1,0 +1,89 @@
+# Getting started with Audit
+
+In the next five minutes you'll install Audit, record your first audit entry, and read it in the Craft control panel. No config, no scaffolding.
+
+## What you need
+
+- Craft CMS 5.5 or later
+- PHP 8.2 or later
+- A Craft install you can log in to, with at least one entry you can edit
+
+If you're still setting up Craft itself, start with the [Craft CMS installation guide](https://craftcms.com/docs/5.x/install.html) and come back when you have a working admin login.
+
+## Install
+
+From the root of your Craft project:
+
+```bash
+composer require superbig/craft-audit
+php craft plugin/install audit
+```
+
+Two lines. If you'd rather click, the control panel works: **Settings → Plugins → Audit → Install**.
+
+The install migration creates the `audit_log` table with composite indexes on `(dateCreated, event)` and `(userId, dateCreated)`, and wires up the event listeners. From this point on, every save, login, and schema change is recorded.
+
+## Your first audit record
+
+Log out of Craft. Log back in. Open **Audit** from the control panel sidebar.
+
+<!-- TODO: screenshot — Audit index page showing a fresh "user-logged-in" record -->
+
+You'll see one row: your own login. Click it.
+
+<!-- TODO: screenshot — detail view of the user-logged-in record -->
+
+The detail view shows the full record:
+
+- **Actor and timestamp.** The user who logged in, and when.
+- **Request context.** IP, user agent, session ID, and request source (`cp` in this case).
+- **Referrer.** Where the request came from.
+
+That's the shape of every record from here on. Every entry save. Every schema change. Every project config edit. Same four groups of data, different payload.
+
+## Make something change
+
+Open any entry in **Entries**. Change the title. Save.
+
+Go back to **Audit**. Refresh. A new row appears at the top: `entry-saved` with the entry's new title. Click through.
+
+<!-- TODO: screenshot — detail view of an entry-saved record with changed-fields panel visible -->
+
+Scroll to the **Changed fields** panel. It shows the old value next to the new one, per field, rendered by Audit's field handlers. For text fields you see a line-by-line diff. For assets and relations, you see the IDs before and after. The full JSON snapshot sits below — click to expand.
+
+That's the core loop. Edit, save, read the record. Now you know what the audit trail looks like when it fires.
+
+## Layer in a field-level diff
+
+Open an entry with a rich-text body. Change a sentence in the middle of the body. Add a line at the end. Save.
+
+Back in **Audit**, open the new record.
+
+<!-- TODO: screenshot — changed-fields panel with before/after body diff -->
+
+The body field now renders as a line-by-line diff: removed lines in red, added lines in green, unchanged context in grey. That's the `RichTextHandler` at work — one of 15 field handlers Audit ships with, one per Craft field type. Plain text, color, date, money, table, Matrix, Neo, SuperTable, Vizy, SEO Framework, options, relations — all diffed in place.
+
+The snapshot still holds the full `getSerializedFieldValues()` output for the entry. The diff is derived data on top, rendered by `DiffRenderer`. You get both: the per-field view for the UI, and the raw JSON for anything else you want to do with it.
+
+If you have a custom field type, Audit doesn't know about it yet — it falls back to a plain-text diff of the serialized value. You can register a handler for it. See `docs/how-to/handle-custom-fields.md` (lands in P3.2).
+
+## What Audit records automatically
+
+Out of the box, with no config:
+
+- Entry, category, asset, user, and global saves and deletes
+- User logins, logouts, activations, suspensions, locks, and group assignments
+- Permission changes — per user and per group
+- Field, section, and entry type changes
+- Filesystem, volume, image transform, and site config changes (via project config)
+- Plugin installs, uninstalls, enables, and disables
+- Console commands and YAML config applies (labeled `console` or `yaml` in the `request` field)
+- Database backups created and restored
+
+The full list lives in the `AuditEvent` enum — 69 cases, grouped by area.
+
+## What's next
+
+- Need to know when a record gets filtered out or what the full lifecycle looks like? See [Events and recording](concepts/events-and-recording.md).
+- Want to drop records you don't care about (console jobs, service accounts, specific event types)? See [How to filter records](how-to/filter-records.md).
+- Want to record events from your own plugin? See `docs/how-to/record-custom-events.md`. Lands in P3.2.

--- a/docs/how-to/filter-records.md
+++ b/docs/how-to/filter-records.md
@@ -1,0 +1,250 @@
+# How to filter records before they save
+
+Your audit log is drowning. A nightly Feed Me import wrote 10,000 rows. A resave job ran on every product. The one change you care about is buried on page 47. Every entry save still produces a record, and filtering the UI after the fact doesn't help when the signal is gone.
+
+`BeforeRecordEvent` is the escape hatch. It fires inside `AuditRecorder::record()` immediately before the row is written. Your listener can cancel the record, mutate the model in place, or tag the snapshot with your own data.
+
+## The hook
+
+One listener. Drops every record. Useful only as a sanity check that the hook is wired up:
+
+```php
+use superbig\audit\events\BeforeRecordEvent;
+use superbig\audit\services\AuditRecorder;
+use yii\base\Event;
+
+Event::on(
+    AuditRecorder::class,
+    AuditRecorder::EVENT_BEFORE_RECORD,
+    function (BeforeRecordEvent $event) {
+        $event->isValid = false;
+    }
+);
+```
+
+Two things to know:
+
+- `$event->model` is the `AuditModel` instance about to be persisted. Its properties are the row-to-be: `event`, `title`, `userId`, `elementType`, `elementId`, `request`, `snapshot` (array), `changedFields` (array), `ip`, `userAgent`, `siteId`, `sessionId`.
+- `$event->isValid = false` cancels the save. The row is never written. `AuditRecorder::record()` returns `null` instead of the model. No exception is thrown.
+
+Mutations to `$event->model` stick. Set `$event->model->snapshot['tenant'] = 'acme'` and that key lands in the DB.
+
+## Recipes
+
+### Drop records from console requests
+
+Feed Me, `php craft resave/entries`, cron-driven imports, and any custom console script all run in a console request. The `request` field on the model captures that: `cp`, `site`, `console`, or `yaml`. If your operators only care about what humans do in the control panel, drop the console writes outright.
+
+```php
+use superbig\audit\events\BeforeRecordEvent;
+use superbig\audit\services\AuditRecorder;
+use yii\base\Event;
+
+Event::on(
+    AuditRecorder::class,
+    AuditRecorder::EVENT_BEFORE_RECORD,
+    function (BeforeRecordEvent $event) {
+        if ($event->model->request === 'console') {
+            $event->isValid = false;
+        }
+    }
+);
+```
+
+Two warnings. First, this drops *all* console writes — including legitimate ad-hoc ones you run by hand. If you want a narrower filter, pair `request === 'console'` with `event === 'entry-saved'` or an `elementType` check. Second, `yaml` is a separate source for project config applies; leave it alone unless you really want to lose schema-change history.
+
+### Drop records for specific event types
+
+Your security team cares about logins. Your content team cares about entry saves. They don't need each other's noise. The `event` field is a kebab-case string; the canonical list lives in the `AuditEvent` enum.
+
+```php
+use superbig\audit\enums\AuditEvent;
+use superbig\audit\events\BeforeRecordEvent;
+use superbig\audit\services\AuditRecorder;
+use yii\base\Event;
+
+Event::on(
+    AuditRecorder::class,
+    AuditRecorder::EVENT_BEFORE_RECORD,
+    function (BeforeRecordEvent $event) {
+        $drop = [
+            AuditEvent::UserLoggedIn->value,
+            AuditEvent::UserLoggedOut->value,
+        ];
+
+        if (in_array($event->model->event, $drop, true)) {
+            $event->isValid = false;
+        }
+    }
+);
+```
+
+Use the enum's `->value` to compare — that's the backing string that matches `$event->model->event`. If you prefer, compare against the enum directly via `$event->model->eventEnum`, which is set when the event string matches a known case.
+
+### Drop records from a service account
+
+You have a `webhook-bot` user that writes entries from incoming webhooks. Its writes aren't interesting; the upstream system already logs them. Filter by user ID.
+
+```php
+use craft\elements\User;
+use superbig\audit\events\BeforeRecordEvent;
+use superbig\audit\services\AuditRecorder;
+use yii\base\Event;
+
+Event::on(
+    AuditRecorder::class,
+    AuditRecorder::EVENT_BEFORE_RECORD,
+    function (BeforeRecordEvent $event) {
+        $botUser = User::find()->username('webhook-bot')->one();
+
+        if ($botUser && $event->model->userId === $botUser->id) {
+            $event->isValid = false;
+        }
+    }
+);
+```
+
+The `User::find()` lookup runs once per audit record, which is fine for a handful of saves and wasteful under a batch. Cache the ID in the listener's closure (or resolve it once in `init()` and capture it) if you're running this under Feed Me.
+
+### Redact sensitive fields from the snapshot
+
+A custom field holds an API key. Another holds a `passwordHash`. Neither belongs in `audit_log`. Keep the record — you still want to know a write happened — but strip the values before the row is written.
+
+```php
+use superbig\audit\events\BeforeRecordEvent;
+use superbig\audit\services\AuditRecorder;
+use yii\base\Event;
+
+Event::on(
+    AuditRecorder::class,
+    AuditRecorder::EVENT_BEFORE_RECORD,
+    function (BeforeRecordEvent $event) {
+        $secret = ['passwordHash', 'secretApiKey', 'stripeSecretKey'];
+
+        if (!empty($event->model->snapshot['content'])) {
+            foreach ($secret as $key) {
+                if (array_key_exists($key, $event->model->snapshot['content'])) {
+                    $event->model->snapshot['content'][$key] = '[redacted]';
+                }
+            }
+        }
+
+        // Also clear these from changedFields so the diff UI doesn't leak them.
+        foreach ($secret as $key) {
+            unset($event->model->changedFields[$key]);
+        }
+    }
+);
+```
+
+The element handler stores serialized field values under `snapshot.content`. That's where your Craft field values live. Project config events store their payload under `snapshot.config` instead — adjust the path if you're redacting config values.
+
+### Tag records with custom metadata
+
+Multi-tenant install, or you run one Craft with `staging` and `production` switched by env. Tag every record with the tenant ID or environment so you can filter later. Mutations to `$event->model->snapshot` are persisted as part of the row.
+
+```php
+use Craft;
+use superbig\audit\events\BeforeRecordEvent;
+use superbig\audit\services\AuditRecorder;
+use yii\base\Event;
+
+Event::on(
+    AuditRecorder::class,
+    AuditRecorder::EVENT_BEFORE_RECORD,
+    function (BeforeRecordEvent $event) {
+        $event->model->snapshot['tenant'] = Craft::parseEnv('$TENANT_ID');
+        $event->model->snapshot['environment'] = Craft::$app->env;
+    }
+);
+```
+
+The `audit_log.snapshot` column is JSON. Your tagged keys survive alongside whatever Audit wrote. Querying by them requires JSON operators (`JSON_EXTRACT` on MySQL, `->>` on Postgres) — possible, not cheap. If you need fast lookup, pair tagging with a structured filter in the CP index via a custom column later.
+
+### Filter to only elements in a specific section
+
+You're running a migration on the `homepage-hero` section and want audit coverage for those entries only. Everything else is noise for the duration. Section info sits in the snapshot under `sectionHandle`, set by `ElementHandler` when the element is an entry.
+
+```php
+use superbig\audit\enums\AuditEvent;
+use superbig\audit\events\BeforeRecordEvent;
+use superbig\audit\services\AuditRecorder;
+use yii\base\Event;
+
+Event::on(
+    AuditRecorder::class,
+    AuditRecorder::EVENT_BEFORE_RECORD,
+    function (BeforeRecordEvent $event) {
+        $entryEvents = [
+            AuditEvent::EntryCreated->value,
+            AuditEvent::EntrySaved->value,
+            AuditEvent::EntryDeleted->value,
+        ];
+
+        if (!in_array($event->model->event, $entryEvents, true)) {
+            return; // not an entry event — leave it alone
+        }
+
+        if (($event->model->snapshot['sectionHandle'] ?? null) !== 'homepage-hero') {
+            $event->isValid = false;
+        }
+    }
+);
+```
+
+The early return matters. Without it you'd drop logins, schema changes, and plugin installs — because they don't have a `sectionHandle`. Scope your filter to the events you actually intend to touch.
+
+## Where to put the listener
+
+`Event::on()` calls need to run during Craft's boot so they're registered before the first save. Three places work:
+
+- A plugin's `init()` method. This is the canonical home for any shipped extension.
+- A custom module's `init()` method. Same lifecycle, less ceremony. Good for site-specific rules.
+- `config/app.php` via the `bootstrap` array. Good for one-off filters that don't warrant a module.
+
+Here's the module pattern — most sites end up with a `modules/sitemodule` in their Craft install:
+
+```php
+namespace modules\sitemodule;
+
+use superbig\audit\events\BeforeRecordEvent;
+use superbig\audit\services\AuditRecorder;
+use yii\base\Event;
+use yii\base\Module;
+
+class SiteModule extends Module
+{
+    public function init(): void
+    {
+        parent::init();
+
+        Event::on(
+            AuditRecorder::class,
+            AuditRecorder::EVENT_BEFORE_RECORD,
+            function (BeforeRecordEvent $event) {
+                if ($event->model->request === 'console') {
+                    $event->isValid = false;
+                }
+            }
+        );
+    }
+}
+```
+
+If you haven't set up a site module yet, the [Craft CMS module documentation](https://craftcms.com/docs/5.x/extend/module-guide.html) covers the scaffolding.
+
+## Limitations
+
+`BeforeRecordEvent` is a per-record hook. That shapes what it can and can't do.
+
+- **Fires per record.** A 10,000-entry Feed Me import fires your listener 10,000 times. Each call skips the DB write when you cancel, which is the dominant cost — but the listener itself runs. Keep filter logic cheap. No `User::find()` inside the hot path without caching.
+- **Can't batch or group records.** This hook doesn't know a batch is happening. If you want a single summary row instead of 10,000 children, that's a separate piece of work. See [events-and-recording](../concepts/events-and-recording.md) for the roadmap.
+- **Runs synchronously.** Every save blocks on your listener. Heavy work (HTTP calls, large DB reads) slows every element save in the request.
+- **Can't rewrite the event type.** Setting `$event->model->event = 'bulk-import-saved'` works, but the CP index view filters, labels, and diff rendering all key off known event strings. A rewritten event will render as an unknown type. Use this for filtering, not for reshaping.
+- **Snapshot mutations happen in-memory.** If your listener throws after mutating `$event->model->snapshot`, there's no rollback and no partial-write. The record is never persisted; the exception propagates up through `AuditRecorder::record()`. Wrap risky work in `try`/`catch` if you need to fail soft.
+- **Doesn't fire for records that were never built.** Audit skips propagation saves, revisions, and (by default) drafts inside the element handler, before `AuditRecorder::record()` is called. Your listener never sees those. That's usually what you want; call it out if you were planning to re-enable them via this hook.
+
+## Related
+
+- [Events and recording](../concepts/events-and-recording.md) — when Audit fires a record, and when it doesn't.
+- `docs/reference/events.md` — full `BeforeRecordEvent` reference. Lands in P3.1.


### PR DESCRIPTION
Part of the v3 refactor stack for [FRE-56](https://linear.app/sanity/issue/FRE-56). Closes [FRE-155](https://linear.app/sanity/issue/fre-155).


Ships the docs escape hatch — Strategy E from `/analysis/batch-processing-strategies.md`:
- `docs/how-to/filter-records.md` (250 lines, 6 recipes for cancelling audit records via `BeforeRecordEvent`)
- `docs/getting-started.md` (89 lines, tutorial)
- `docs/concepts/events-and-recording.md` (108 lines, explanation)

All voice-calibrated. Banned-word greps clean (no "simply", "just", "easy", "obviously", etc.).

### Stack navigation

↑ Builds on **#111** `ci-php-matrix-hygiene` (P2.5)
↓ Top of stack

### Review notes

- Single-commit branch
- This is a **draft** — not a request to merge yet. Marked ready when the stack is approved end-to-end.

