### PR TITLE
Phase 2.5 — CI: PHP 8.2/8.3/8.4 matrix + v3 branch trigger

### DIFF
--- a/.github/workflows/code-analysis.yaml
+++ b/.github/workflows/code-analysis.yaml
@@ -28,7 +28,7 @@ jobs:
         id: setup-php
         uses: shivammathur/setup-php@v2
         with:
-          php-version: 8.2
+          php-version: 8.3
           extensions: 'ctype,curl,dom,iconv,imagick,intl,json,mbstring,openssl,pcre,pdo,reflection,spl,zip'
           ini-values: post_max_size=256M, max_execution_time=180, memory_limit=512M
           tools: composer:v2

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -6,6 +6,7 @@ on:
     branches:
       - main
       - chore/craft5-support
+      - v3
 
 permissions:
   contents: read
@@ -16,6 +17,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
+        php: ['8.2', '8.3', '8.4']
         database: [mysql, postgres]
         include:
           - database: mysql
@@ -69,7 +71,7 @@ jobs:
 
       - uses: shivammathur/setup-php@v2
         with:
-          php-version: '8.3'
+          php-version: ${{ matrix.php }}
 
       - name: Validate composer.json
         run: composer validate --strict


### PR DESCRIPTION
Part of the v3 refactor stack for [FRE-56](https://linear.app/sanity/issue/FRE-56). Closes [FRE-134](https://linear.app/sanity/issue/fre-134).


CI improvements:
- Add PHP 8.2, 8.3, 8.4 matrix to test runs
- Trigger workflows on v3 branch (was main only)
- Bump code-analysis (PHPStan + ECS) to PHP 8.3

### Stack navigation

↑ Builds on **#99** `tests-migrate-to-audit-event-enum` (P2.4)
↓ Followed by **#110** `docs-escape-hatch` (P3.0)

### Review notes

- Single-commit branch
- This is a **draft** — not a request to merge yet. Marked ready when the stack is approved end-to-end.

