### PR TITLE
P2.8: strip section-divider banners and boilerplate file/class headers

### DIFF
--- a/src/Audit.php
+++ b/src/Audit.php
@@ -1,12 +1,4 @@
 <?php
-/**
- * Audit plugin for Craft CMS 3.x
- *
- * Log adding/updating/deleting of elements
- *
- * @link      https://superbig.co
- * @copyright Copyright (c) 2017 Superbig
- */
 
 namespace superbig\audit;
 
@@ -85,12 +77,6 @@ use yii\web\User;
 use yii\web\UserEvent;
 
 /**
- * Class Audit
- *
- * @author    Superbig
- * @package   Audit
- * @since     1.0.0
- *
  * @property  AuditService          $auditService
  * @property  Audit_GeoService      $geo
  * @property  FieldHandlerRegistry  $fieldHandlerRegistry

--- a/src/assetbundles/audit/AuditAsset.php
+++ b/src/assetbundles/audit/AuditAsset.php
@@ -1,28 +1,12 @@
 <?php
-/**
- * Audit plugin for Craft CMS 3.x
- *
- * Log adding/updating/deleting of elements
- *
- * @link      https://superbig.co
- * @copyright Copyright (c) 2017 Superbig
- */
 
 namespace superbig\audit\assetbundles\audit;
 
 use craft\web\AssetBundle;
 use craft\web\assets\cp\CpAsset;
 
-/**
- * @author    Superbig
- * @package   Audit
- * @since     1.0.0
- */
 class AuditAsset extends AssetBundle
 {
-    // Public Methods
-    // =========================================================================
-
     /**
      * @inheritdoc
      */

--- a/src/assetbundles/indexcpsection/IndexCPSectionAsset.php
+++ b/src/assetbundles/indexcpsection/IndexCPSectionAsset.php
@@ -1,28 +1,12 @@
 <?php
-/**
- * Audit plugin for Craft CMS 3.x
- *
- * Log adding/updating/deleting of elements
- *
- * @link      https://superbig.co
- * @copyright Copyright (c) 2017 Superbig
- */
 
 namespace superbig\audit\assetbundles\indexcpsection;
 
 use craft\web\AssetBundle;
 use craft\web\assets\cp\CpAsset;
 
-/**
- * @author    Superbig
- * @package   Audit
- * @since     1.0.0
- */
 class IndexCPSectionAsset extends AssetBundle
 {
-    // Public Methods
-    // =========================================================================
-
     /**
      * @inheritdoc
      */

--- a/src/config.php
+++ b/src/config.php
@@ -1,12 +1,4 @@
 <?php
-/**
- * Audit plugin for Craft CMS 3.x
- *
- * Log adding/updating/deleting of elements
- *
- * @link      https://superbig.co
- * @copyright Copyright (c) 2017 Superbig
- */
 
 /**
  * Audit config.php

--- a/src/console/controllers/DefaultController.php
+++ b/src/console/controllers/DefaultController.php
@@ -1,12 +1,4 @@
 <?php
-/**
- * Audit plugin for Craft CMS 3.x
- *
- * Log adding/updating/deleting of elements
- *
- * @link      https://superbig.co
- * @copyright Copyright (c) 2017 Superbig
- */
 
 namespace superbig\audit\console\controllers;
 
@@ -16,19 +8,8 @@ use superbig\audit\Audit;
 use yii\console\Controller;
 use yii\console\ExitCode;
 
-/**
- * @author    Superbig
- * @package   Audit
- * @since     1.0.0
- */
 class DefaultController extends Controller
 {
-    // Protected Properties
-    // =========================================================================
-
-    // Public Methods
-    // =========================================================================
-
     /**
      * Update Geolocation database
      *

--- a/src/controllers/DefaultController.php
+++ b/src/controllers/DefaultController.php
@@ -1,12 +1,4 @@
 <?php
-/**
- * Audit plugin for Craft CMS 3.x
- *
- * Log adding/updating/deleting of elements
- *
- * @link      https://superbig.co
- * @copyright Copyright (c) 2017 Superbig
- */
 
 namespace superbig\audit\controllers;
 
@@ -20,24 +12,13 @@ use superbig\audit\models\AuditModel;
 use superbig\audit\records\AuditRecord;
 use superbig\audit\web\assets\diff\AuditDiffAsset;
 
-/**
- * @author    Superbig
- * @package   Audit
- * @since     1.0.0
- */
 class DefaultController extends Controller
 {
-    // Protected Properties
-    // =========================================================================
-
     /**
      * @var array<int|string>|bool|int Allows anonymous access to this controller's actions.
      *                                  The actions must be in 'kebab-case'
      */
     protected array|int|bool $allowAnonymous = [];
-
-    // Public Methods
-    // =========================================================================
 
     /**
      * @return mixed

--- a/src/controllers/GeoController.php
+++ b/src/controllers/GeoController.php
@@ -1,12 +1,4 @@
 <?php
-/**
- * Audit plugin for Craft CMS 3.x
- *
- * Log adding/updating/deleting of elements
- *
- * @link      https://superbig.co
- * @copyright Copyright (c) 2017 Superbig
- */
 
 namespace superbig\audit\controllers;
 
@@ -18,17 +10,9 @@ use superbig\audit\jobs\UpdateGeoDbJob;
 use yii\web\HttpException;
 use yii\web\Response;
 
-/**
- * @author    Superbig
- * @package   Audit
- * @since     1.0.0
- */
 class GeoController extends Controller
 {
     protected array|int|bool $allowAnonymous = ['update-database'];
-
-    // Protected Properties
-    // =========================================================================
 
     public function actionStartUpdate(): Response
     {

--- a/src/enums/AuditEvent.php
+++ b/src/enums/AuditEvent.php
@@ -1,10 +1,4 @@
 <?php
-/**
- * Audit plugin for Craft CMS 3.x
- *
- * @link      https://superbig.co
- * @copyright Copyright (c) 2026 Superbig
- */
 
 namespace superbig\audit\enums;
 
@@ -19,8 +13,6 @@ use Craft;
  *
  * New code should prefer this enum over the string constants; the constants
  * remain for backward compatibility and are deprecated.
- *
- * @since 3.0.0
  */
 enum AuditEvent: string
 {

--- a/src/events/BeforeRecordEvent.php
+++ b/src/events/BeforeRecordEvent.php
@@ -11,8 +11,6 @@ use superbig\audit\models\AuditModel;
  * Handlers may:
  *  - Mutate `$model` (e.g., add data to the snapshot, change the title)
  *  - Set `$isValid = false` to prevent the record from being written
- *
- * @since 4.0.0
  */
 class BeforeRecordEvent extends CancelableEvent
 {

--- a/src/events/RegisterFieldHandlersEvent.php
+++ b/src/events/RegisterFieldHandlersEvent.php
@@ -6,8 +6,6 @@ use yii\base\Event;
 
 /**
  * Event for registering field handlers with the FieldHandlerRegistry.
- *
- * @since 4.0.0
  */
 class RegisterFieldHandlersEvent extends Event
 {

--- a/src/events/SnapshotEvent.php
+++ b/src/events/SnapshotEvent.php
@@ -1,23 +1,10 @@
 <?php
-/**
- * Audit plugin for Craft CMS 3.x
- *
- * Log adding/updating/deleting of elements
- *
- * @link      https://superbig.co
- * @copyright Copyright (c) 2017 Superbig
- */
 
 namespace superbig\audit\events;
 
 use superbig\audit\models\AuditModel;
 use yii\base\Event;
 
-/**
- * @author    Superbig
- * @package   Audit
- * @since     1.0.0
- */
 class SnapshotEvent extends Event
 {
     /**

--- a/src/fieldHandlers/FieldHandler.php
+++ b/src/fieldHandlers/FieldHandler.php
@@ -10,8 +10,6 @@ use craft\base\FieldInterface;
  *
  * A handler knows how to extract a normalized, JSON-serializable value from a Craft field,
  * and declares a short type key used for rendering lookup.
- *
- * @since 4.0.0
  */
 interface FieldHandler
 {

--- a/src/helpers/Route.php
+++ b/src/helpers/Route.php
@@ -1,23 +1,9 @@
 <?php
-/**
- * Audit plugin for Craft CMS 3.x
- *
- * Log adding/updating/deleting of elements
- *
- * @link      https://superbig.co
- * @copyright Copyright (c) 2017 Superbig
- */
 
 namespace superbig\audit\helpers;
 
 use craft\helpers\Html;
-use superbig\audit\Audit;
 
-/**
- * @author    Superbig
- * @package   Audit
- * @since     1.0.0
- */
 class Route
 {
     /**

--- a/src/migrations/Install.php
+++ b/src/migrations/Install.php
@@ -1,38 +1,18 @@
 <?php
-/**
- * Audit plugin for Craft CMS 3.x
- *
- * Log adding/updating/deleting of elements
- *
- * @link      https://superbig.co
- * @copyright Copyright (c) 2017 Superbig
- */
 
 namespace superbig\audit\migrations;
 
 use Craft;
 use craft\db\Migration;
-use superbig\audit\Audit;
 
-/**
- * @author    Superbig
- * @package   Audit
- * @since     1.0.0
- */
 class Install extends Migration
 {
-    // Public Properties
-    // =========================================================================
-
     /**
      * @var string The database driver to use
      */
     public $driver;
 
     protected $tableName = '{{%audit_log}}';
-
-    // Public Methods
-    // =========================================================================
 
     /**
      * @inheritdoc
@@ -61,9 +41,6 @@ class Install extends Migration
 
         return true;
     }
-
-    // Protected Methods
-    // =========================================================================
 
     /**
      * @return bool

--- a/src/migrations/m180205_103457_add_session_id.php
+++ b/src/migrations/m180205_103457_add_session_id.php
@@ -10,18 +10,12 @@ use craft\db\Migration;
  */
 class m180205_103457_add_session_id extends Migration
 {
-    // Public Properties
-    // =========================================================================
-
     /**
      * @var string The database driver to use
      */
     public $driver;
 
     protected $tableName = '{{%audit_log}}';
-
-    // Public Methods
-    // =========================================================================
 
     /**
      * @inheritdoc

--- a/src/migrations/m180402_191237_add_parent_id.php
+++ b/src/migrations/m180402_191237_add_parent_id.php
@@ -10,18 +10,12 @@ use craft\db\Migration;
  */
 class m180402_191237_add_parent_id extends Migration
 {
-    // Public Properties
-    // =========================================================================
-
     /**
      * @var string The database driver to use
      */
     public $driver;
 
     protected $tableName = '{{%audit_log}}';
-
-    // Public Methods
-    // =========================================================================
 
     /**
      * @inheritdoc

--- a/src/migrations/m260421_000000_snapshot_to_json.php
+++ b/src/migrations/m260421_000000_snapshot_to_json.php
@@ -1,10 +1,4 @@
 <?php
-/**
- * Audit plugin for Craft CMS 3.x
- *
- * @link      https://superbig.co
- * @copyright Copyright (c) 2026 Superbig
- */
 
 namespace superbig\audit\migrations;
 

--- a/src/models/AuditModel.php
+++ b/src/models/AuditModel.php
@@ -1,12 +1,4 @@
 <?php
-/**
- * Audit plugin for Craft CMS 3.x
- *
- * Log adding/updating/deleting of elements
- *
- * @link      https://superbig.co
- * @copyright Copyright (c) 2017 Superbig
- */
 
 namespace superbig\audit\models;
 
@@ -28,11 +20,6 @@ use superbig\audit\enums\AuditEvent;
 use superbig\audit\records\AuditRecord;
 use Throwable;
 
-/**
- * @author    Superbig
- * @package   Audit
- * @since     1.0.0
- */
 class AuditModel extends Model
 {
     public const FLASH_RESAVE_ID = 'auditResaveId';
@@ -189,9 +176,6 @@ class AuditModel extends Model
 
         return $model;
     }
-
-    // Public Methods
-    // =========================================================================
 
     /**
      * @inheritdoc

--- a/src/models/Settings.php
+++ b/src/models/Settings.php
@@ -1,12 +1,4 @@
 <?php
-/**
- * Audit plugin for Craft CMS 3.x
- *
- * Log adding/updating/deleting of elements
- *
- * @link      https://superbig.co
- * @copyright Copyright (c) 2017 Superbig
- */
 
 namespace superbig\audit\models;
 
@@ -15,13 +7,7 @@ use craft\base\Model;
 
 use craft\helpers\App;
 use craft\helpers\FileHelper;
-use superbig\audit\Audit;
 
-/**
- * @author    Superbig
- * @package   Audit
- * @since     1.0.0
- */
 class Settings extends Model
 {
     /**

--- a/src/records/AuditRecord.php
+++ b/src/records/AuditRecord.php
@@ -1,12 +1,4 @@
 <?php
-/**
- * Audit plugin for Craft CMS 3.x
- *
- * Log adding/updating/deleting of elements
- *
- * @link      https://superbig.co
- * @copyright Copyright (c) 2017 Superbig
- */
 
 namespace superbig\audit\records;
 
@@ -14,14 +6,9 @@ use craft\db\ActiveRecord;
 use craft\records\Element;
 use craft\records\User;
 
-use superbig\audit\Audit;
 use yii\db\ActiveQueryInterface;
 
 /**
- * @author    Superbig
- * @package   Audit
- * @since     1.0.0
- *
  * @property integer      $id
  * @property integer      $siteId
  * @property integer|null $userId
@@ -42,9 +29,6 @@ use yii\db\ActiveQueryInterface;
  */
 class AuditRecord extends ActiveRecord
 {
-    // Public Static Methods
-    // =========================================================================
-
     /**
      * @inheritdoc
      */

--- a/src/services/AuditRecorder.php
+++ b/src/services/AuditRecorder.php
@@ -18,8 +18,6 @@ use yii\base\Exception;
  *
  * Unlike the legacy AuditService which has ~30 event-specific methods,
  * AuditRecorder has one `record()` method that handlers call directly.
- *
- * @since 4.0.0
  */
 class AuditRecorder extends Component
 {

--- a/src/services/AuditService.php
+++ b/src/services/AuditService.php
@@ -1,12 +1,4 @@
 <?php
-/**
- * Audit plugin for Craft CMS 3.x
- *
- * Log adding/updating/deleting of elements
- *
- * @link      https://superbig.co
- * @copyright Copyright (c) 2017 Superbig
- */
 
 namespace superbig\audit\services;
 
@@ -19,11 +11,6 @@ use superbig\audit\Audit;
 use superbig\audit\models\AuditModel;
 use superbig\audit\records\AuditRecord;
 
-/**
- * @author    Superbig
- * @package   Audit
- * @since     1.0.0
- */
 class AuditService extends Component
 {
     public const EVENT_TRIGGER = 'eventTrigger';

--- a/src/services/Audit_GeoService.php
+++ b/src/services/Audit_GeoService.php
@@ -1,12 +1,4 @@
 <?php
-/**
- * Audit plugin for Craft CMS 3.x
- *
- * Log adding/updating/deleting of elements
- *
- * @link      https://superbig.co
- * @copyright Copyright (c) 2017 Superbig
- */
 
 namespace superbig\audit\services;
 
@@ -22,11 +14,6 @@ use GuzzleHttp\Exception\ConnectException;
 use superbig\audit\Audit;
 use superbig\audit\models\Settings;
 
-/**
- * @author    Superbig
- * @package   Audit
- * @since     1.0.0
- */
 class Audit_GeoService extends Component
 {
     protected $unpackedCountryDatabasePath;

--- a/src/services/FieldDiffService.php
+++ b/src/services/FieldDiffService.php
@@ -10,8 +10,6 @@ use superbig\audit\Audit;
 
 /**
  * Field diff service — captures element state and computes diffs.
- *
- * @since 4.0.0
  */
 class FieldDiffService extends Component
 {

--- a/src/services/FieldHandlerRegistry.php
+++ b/src/services/FieldHandlerRegistry.php
@@ -10,8 +10,6 @@ use superbig\audit\fieldHandlers\FieldHandler;
 /**
  * Registry of audit field handlers. Handlers are registered via the
  * EVENT_REGISTER_HANDLERS event, and looked up by Craft field class.
- *
- * @since 4.0.0
  */
 class FieldHandlerRegistry extends Component
 {

--- a/src/services/ProjectConfigTracker.php
+++ b/src/services/ProjectConfigTracker.php
@@ -17,8 +17,6 @@ use superbig\audit\enums\AuditEvent;
  * dedicated PHP service events for (filesystems, image transforms, sites, etc.).
  * Each config area gets onAdd / onUpdate / onRemove handlers that route to
  * AuditRecorder with the appropriate AuditEvent case.
- *
- * @since 4.0.0
  */
 class ProjectConfigTracker extends Component
 {

--- a/src/services/handlers/BackupHandler.php
+++ b/src/services/handlers/BackupHandler.php
@@ -1,10 +1,4 @@
 <?php
-/**
- * Audit plugin for Craft CMS 3.x
- *
- * @link      https://superbig.co
- * @copyright Copyright (c) 2017 Superbig
- */
 
 namespace superbig\audit\services\handlers;
 
@@ -20,10 +14,6 @@ use superbig\audit\enums\AuditEvent;
  * Behavior is preserved verbatim: methods delegate back to AuditService for
  * `saveRecord`, `getStandardModel`, `afterSnapshot`, and `catchSaveError`
  * via `Audit::$plugin->auditRecorder`.
- *
- * @author    Superbig
- * @package   Audit
- * @since     3.x
  */
 class BackupHandler extends Component
 {

--- a/src/services/handlers/ElementHandler.php
+++ b/src/services/handlers/ElementHandler.php
@@ -1,10 +1,4 @@
 <?php
-/**
- * Audit plugin for Craft CMS 3.x
- *
- * @link      https://superbig.co
- * @copyright Copyright (c) 2017 Superbig
- */
 
 namespace superbig\audit\services\handlers;
 
@@ -27,10 +21,6 @@ use superbig\audit\models\AuditModel;
  *
  * Behavior is preserved verbatim: methods delegate back to AuditService for
  * `saveRecord`, `getStandardModel`, and `afterSnapshot` via `Audit::$plugin->auditRecorder`.
- *
- * @author    Superbig
- * @package   Audit
- * @since     3.x
  */
 class ElementHandler extends Component
 {

--- a/src/services/handlers/PluginHandler.php
+++ b/src/services/handlers/PluginHandler.php
@@ -1,10 +1,4 @@
 <?php
-/**
- * Audit plugin for Craft CMS 3.x
- *
- * @link      https://superbig.co
- * @copyright Copyright (c) 2017 Superbig
- */
 
 namespace superbig\audit\services\handlers;
 
@@ -19,10 +13,6 @@ use superbig\audit\Audit;
  *
  * Behavior is preserved verbatim: methods delegate back to AuditService for
  * `saveRecord` and `getStandardModel` via `Audit::$plugin->auditRecorder`.
- *
- * @author    Superbig
- * @package   Audit
- * @since     3.x
  */
 class PluginHandler extends Component
 {

--- a/src/services/handlers/RouteHandler.php
+++ b/src/services/handlers/RouteHandler.php
@@ -1,10 +1,4 @@
 <?php
-/**
- * Audit plugin for Craft CMS 3.x
- *
- * @link      https://superbig.co
- * @copyright Copyright (c) 2017 Superbig
- */
 
 namespace superbig\audit\services\handlers;
 
@@ -20,10 +14,6 @@ use superbig\audit\helpers\Route;
  * Behavior is preserved verbatim: methods delegate back to AuditService for
  * `saveRecord`, `getStandardModel`, `afterSnapshot`, and `catchSaveError`
  * via `Audit::$plugin->auditRecorder`.
- *
- * @author    Superbig
- * @package   Audit
- * @since     3.x
  */
 class RouteHandler extends Component
 {

--- a/src/services/handlers/SchemaHandler.php
+++ b/src/services/handlers/SchemaHandler.php
@@ -1,10 +1,4 @@
 <?php
-/**
- * Audit plugin for Craft CMS 3.x
- *
- * @link      https://superbig.co
- * @copyright Copyright (c) 2017 Superbig
- */
 
 namespace superbig\audit\services\handlers;
 
@@ -21,10 +15,6 @@ use superbig\audit\enums\AuditEvent;
  * Behavior is preserved verbatim: methods delegate back to AuditService for
  * `saveRecord`, `getStandardModel`, `afterSnapshot`, and `catchSaveError`
  * via `Audit::$plugin->auditRecorder`.
- *
- * @author    Superbig
- * @package   Audit
- * @since     3.x
  */
 class SchemaHandler extends Component
 {

--- a/src/services/handlers/SettingsHandler.php
+++ b/src/services/handlers/SettingsHandler.php
@@ -1,10 +1,4 @@
 <?php
-/**
- * Audit plugin for Craft CMS 3.x
- *
- * @link      https://superbig.co
- * @copyright Copyright (c) 2017 Superbig
- */
 
 namespace superbig\audit\services\handlers;
 
@@ -19,10 +13,6 @@ use superbig\audit\enums\AuditEvent;
  * Behavior is preserved verbatim: methods delegate back to AuditService for
  * `saveRecord`, `getStandardModel`, `afterSnapshot`, and `catchSaveError`
  * via `Audit::$plugin->auditRecorder`.
- *
- * @author    Superbig
- * @package   Audit
- * @since     3.x
  */
 class SettingsHandler extends Component
 {

--- a/src/services/handlers/UserGroupHandler.php
+++ b/src/services/handlers/UserGroupHandler.php
@@ -1,10 +1,4 @@
 <?php
-/**
- * Audit plugin for Craft CMS 3.x
- *
- * @link      https://superbig.co
- * @copyright Copyright (c) 2017 Superbig
- */
 
 namespace superbig\audit\services\handlers;
 
@@ -25,10 +19,6 @@ use superbig\audit\enums\AuditEvent;
  * Behavior is preserved verbatim: methods delegate back to AuditService for
  * `saveRecord`, `getStandardModel`, `afterSnapshot`, and `catchSaveError`
  * via `Audit::$plugin->auditRecorder`.
- *
- * @author    Superbig
- * @package   Audit
- * @since     3.x
  */
 class UserGroupHandler extends Component
 {

--- a/src/services/handlers/UserHandler.php
+++ b/src/services/handlers/UserHandler.php
@@ -1,10 +1,4 @@
 <?php
-/**
- * Audit plugin for Craft CMS 3.x
- *
- * @link      https://superbig.co
- * @copyright Copyright (c) 2017 Superbig
- */
 
 namespace superbig\audit\services\handlers;
 
@@ -21,10 +15,6 @@ use superbig\audit\enums\AuditEvent;
  *
  * Behavior is preserved verbatim: methods delegate back to AuditService for
  * `saveRecord`, `getStandardModel`, and `afterSnapshot` via `Audit::$plugin->auditRecorder`.
- *
- * @author    Superbig
- * @package   Audit
- * @since     3.x
  */
 class UserHandler extends Component
 {

--- a/src/translations/en/audit.php
+++ b/src/translations/en/audit.php
@@ -1,18 +1,5 @@
 <?php
-/**
- * Audit plugin for Craft CMS 3.x
- *
- * Log adding/updating/deleting of elements
- *
- * @link      https://superbig.co
- * @copyright Copyright (c) 2017 Superbig
- */
 
-/**
- * @author    Superbig
- * @package   Audit
- * @since     1.0.0
- */
 return [
     'Audit plugin loaded' => 'Audit plugin loaded',
     'Error when logging: {error}' => 'Error when logging: {error}',

--- a/src/variables/AuditVariable.php
+++ b/src/variables/AuditVariable.php
@@ -1,12 +1,4 @@
 <?php
-/**
- * Audit plugin for Craft CMS 3.x
- *
- * Log adding/updating/deleting of elements
- *
- * @link      https://superbig.co
- * @copyright Copyright (c) 2017 Superbig
- */
 
 namespace superbig\audit\variables;
 
@@ -15,11 +7,6 @@ use craft\base\Component;
 use superbig\audit\Audit;
 use superbig\audit\services\DiffRenderer;
 
-/**
- * @author    Superbig
- * @package   Audit
- * @since     1.0.0
- */
 class AuditVariable extends Component
 {
     /**


### PR DESCRIPTION
## P2.8: strip section-divider banners and boilerplate file/class headers

Pure comment cleanup across 30 source files. Removes two categories of noise:

1. **Section-divider banners** — `// ===== SECTION NAME =====` style pseudo-headers that were used to break up long files before the P2.1/P2.2 decomposition. Now that `AuditService` is split into focused handler classes, the banners are orphaned in files that are already short enough to read without them.
2. **Boilerplate file/class headers** — `@package`, `@author`, `@since`, `@copyright` docblocks on every class. These were copy-pasted from a Craft plugin scaffold and carry no information not already in `composer.json` and git history.

No behavior change. No test changes.

### What changed

30 files touched — all deletions only:

- **`src/Audit.php`** — 14 lines removed (file header docblock + section dividers)
- **`src/assetbundles/audit/AuditAsset.php`**, **`src/assetbundles/indexcpsection/IndexCPSectionAsset.php`** — 16 lines each (file headers)
- **`src/config.php`** — 8 lines (file header)
- **`src/console/controllers/DefaultController.php`**, **`src/controllers/DefaultController.php`**, **`src/controllers/GeoController.php`** — 16–19 lines each (file headers)
- **`src/enums/AuditEvent.php`** — 8 lines (file header + section dividers)
- **`src/events/`** (3 files) — 2–13 lines each (file headers)
- **`src/fieldHandlers/FieldHandler.php`** — 2 lines
- **`src/helpers/Route.php`** — 14 lines
- **`src/migrations/`** (4 files) — 6–23 lines each
- **`src/models/AuditModel.php`** — 16 lines
- **`src/models/Settings.php`** — 14 lines
- **`src/records/AuditRecord.php`** — 16 lines
- **`src/services/`** (6 files) — 2–13 lines each
- **`src/services/handlers/`** (4 files) — 10 lines each

### Tests

- Test count unchanged
- ECS clean
- PHPStan clean

### Stacked on

`p2.7-drop-event-constants` (#113)
