### PR TITLE
P3.1: batch processing foundation — BatchService + auto-attach + 3 enum cases + 13 tests

### DIFF
--- a/src/Audit.php
+++ b/src/Audit.php
@@ -57,6 +57,7 @@ use superbig\audit\models\Settings;
 use superbig\audit\services\Audit_GeoService;
 use superbig\audit\services\AuditRecorder;
 use superbig\audit\services\AuditService;
+use superbig\audit\services\BatchService;
 use superbig\audit\services\DiffRenderer;
 use superbig\audit\services\FieldDiffService;
 use superbig\audit\services\FieldHandlerRegistry;
@@ -92,6 +93,7 @@ use yii\web\UserEvent;
  * @property  BackupHandler         $backupHandler
  * @property  PluginHandler         $pluginHandler
  * @property  SettingsHandler       $settingsHandler
+ * @property  BatchService          $batch
  * @method  Settings getSettings()
  */
 class Audit extends Plugin
@@ -155,6 +157,7 @@ class Audit extends Plugin
             'backupHandler' => BackupHandler::class,
             'pluginHandler' => PluginHandler::class,
             'settingsHandler' => SettingsHandler::class,
+            'batch' => BatchService::class,
         ]);
 
         $this->registerFieldHandlers();

--- a/src/enums/AuditEvent.php
+++ b/src/enums/AuditEvent.php
@@ -127,6 +127,11 @@ enum AuditEvent: string
     case GlobalSetConfigSaved = 'global-set-config-saved';
     case GlobalSetConfigDeleted = 'global-set-config-deleted';
 
+    // ===== Batch lifecycle (P3.1) =====
+    case BatchStarted = 'batch-started';
+    case BatchCompleted = 'batch-completed';
+    case BatchFailed = 'batch-failed';
+
     /**
      * Human-readable, translated label for this event.
      *

--- a/src/events/BatchEndedEvent.php
+++ b/src/events/BatchEndedEvent.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace superbig\audit\events;
+
+use yii\base\Event;
+
+/**
+ * Event triggered when a batch is closed via {@see \superbig\audit\services\BatchService::close()}.
+ *
+ * Fires for both successful and failed batches — distinguish via the `state`
+ * property ('completed' or 'failed').
+ *
+ * This event is observational. Use it to react to batch completion, e.g.,
+ * emit a notification or roll up child counts into a dashboard.
+ */
+class BatchEndedEvent extends Event
+{
+    public int $batchId;
+    public string $title;
+    /** @var string 'completed' or 'failed' */
+    public string $state;
+    public ?int $durationMs = null;
+    public int $childCount = 0;
+    public array $summary = [];
+}

--- a/src/events/BatchStartedEvent.php
+++ b/src/events/BatchStartedEvent.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace superbig\audit\events;
+
+use yii\base\Event;
+
+/**
+ * Event triggered when a batch is opened via {@see \superbig\audit\services\BatchService::open()}.
+ *
+ * Listeners receive the batch's audit row ID, the human-readable title,
+ * and the metadata array supplied to open().
+ *
+ * This event is observational and cannot cancel the batch.
+ */
+class BatchStartedEvent extends Event
+{
+    public int $batchId;
+    public string $title;
+    public array $metadata = [];
+}

--- a/src/services/AuditRecorder.php
+++ b/src/services/AuditRecorder.php
@@ -63,6 +63,15 @@ class AuditRecorder extends Component
             }
         }
 
+        // Auto-attach to the currently-open batch if no parentId override was provided.
+        // Note: when BatchService::open() calls record() to create the batch row itself,
+        // it hasn't pushed onto the stack yet — so currentBatchId() returns null (or the
+        // outer batch's id for nested batches, in which case it's already supplied via
+        // overrides above). This prevents a batch row from auto-attaching to itself.
+        if ($model->parentId === null) {
+            $model->parentId = Audit::$plugin->batch->currentBatchId();
+        }
+
         // Fire BeforeRecord event — allows mutation / cancellation
         $beforeEvent = new BeforeRecordEvent(['model' => $model]);
         $this->trigger(self::EVENT_BEFORE_RECORD, $beforeEvent);

--- a/src/services/BatchService.php
+++ b/src/services/BatchService.php
@@ -1,0 +1,243 @@
+<?php
+
+namespace superbig\audit\services;
+
+use Closure;
+use Craft;
+use craft\helpers\Json;
+use RuntimeException;
+use superbig\audit\Audit;
+use superbig\audit\enums\AuditEvent;
+use superbig\audit\events\BatchEndedEvent;
+use superbig\audit\events\BatchStartedEvent;
+use superbig\audit\records\AuditRecord;
+use Throwable;
+use yii\base\Component;
+
+/**
+ * Public batch processing API.
+ *
+ * Open a batch, do work, close the batch. Any audit records written between
+ * `open()` and `close()` automatically inherit `parentId` from the currently
+ * open batch (via {@see AuditRecorder::record()}), giving you a single parent
+ * row that aggregates an arbitrary tree of child events.
+ *
+ * Three call shapes:
+ *
+ *   // Scoped (preferred): callback boundary handles open/close + failure path.
+ *   Audit::$plugin->batch->run('Import products', function () {
+ *       // ... record events ...
+ *   });
+ *
+ *   // Manual: caller controls the lifecycle (e.g., across queue jobs).
+ *   $id = Audit::$plugin->batch->open('Long-running import');
+ *   // ...
+ *   Audit::$plugin->batch->close($id);
+ *
+ *   // Introspection
+ *   Audit::$plugin->batch->currentBatchId();   // innermost open batch or null
+ *   Audit::$plugin->batch->openBatches();      // stack, outermost first
+ *
+ * Batches can be nested. The nested batch row inherits the outer batch as its
+ * parent, and records inside the nested batch attach to the nested batch.
+ *
+ * Request-scoped state — the stack is not persisted across requests.
+ */
+class BatchService extends Component
+{
+    public const EVENT_BATCH_STARTED = 'batchStarted';
+    public const EVENT_BATCH_ENDED = 'batchEnded';
+
+    /** @var int[] Stack of currently-open batch IDs (innermost last). Request-scoped. */
+    private array $stack = [];
+
+    /**
+     * @var array<int, array{title: string, openedAt: float, metadata: array}>
+     *      Per-batch in-memory state for summary computation.
+     */
+    private array $state = [];
+
+    /**
+     * Open a batch, run the callback, close the batch.
+     *
+     * If the callback throws, the batch is closed with state='failed' before
+     * the exception is re-thrown.
+     *
+     * @template T
+     * @param Closure(): T $callback
+     * @return T
+     */
+    public function run(string $title, Closure $callback, array $metadata = []): mixed
+    {
+        $batchId = $this->open($title, $metadata);
+
+        try {
+            $result = $callback();
+            $this->close($batchId);
+            return $result;
+        } catch (Throwable $e) {
+            $this->close($batchId, failed: true);
+            throw $e;
+        }
+    }
+
+    /**
+     * Open a new batch — writes a parent audit row, pushes onto the stack,
+     * fires EVENT_BATCH_STARTED, and returns the batch's audit row ID.
+     *
+     * If a batch is already open, the new batch's parent row inherits it via
+     * an explicit `parentId` override (not auto-attach, since the new batch
+     * isn't on the stack yet — see the comment below for re-entrancy details).
+     */
+    public function open(string $title, array $metadata = []): int
+    {
+        $snapshot = [
+            'state' => 'running',
+            'openedAt' => date('c'),
+            'metadata' => $metadata,
+        ];
+
+        // If we're nested, explicitly pass parentId so the new batch row
+        // attaches to the currently-open batch. We pass it via overrides
+        // rather than relying on auto-attach because at this point the new
+        // batch isn't on the stack yet (see below).
+        $overrides = [];
+        $parent = $this->currentBatchId();
+        if ($parent !== null) {
+            $overrides['parentId'] = $parent;
+        }
+
+        // IMPORTANT — re-entrancy: do NOT push onto $this->stack until AFTER
+        // record() returns. The new batch row is created by record(); if we
+        // pushed first, AuditRecorder's auto-attach hook would set the new
+        // row's parentId to its own (future) id, which is nonsense.
+        $model = Audit::$plugin->auditRecorder->record(
+            event: AuditEvent::BatchStarted,
+            title: $title,
+            snapshot: $snapshot,
+            overrides: $overrides,
+        );
+
+        if ($model === null || $model->id === null) {
+            throw new RuntimeException(
+                'BatchService::open(): failed to persist parent batch row '
+                . '(record() returned null — likely cancelled by a BeforeRecord listener or save failure).'
+            );
+        }
+
+        $batchId = (int) $model->id;
+
+        // Now safe to push — the parent row is persisted with its correct
+        // parentId (either null or the outer batch's id from overrides).
+        $this->stack[] = $batchId;
+        $this->state[$batchId] = [
+            'title' => $title,
+            'openedAt' => microtime(true),
+            'metadata' => $metadata,
+        ];
+
+        $this->trigger(self::EVENT_BATCH_STARTED, new BatchStartedEvent([
+            'batchId' => $batchId,
+            'title' => $title,
+            'metadata' => $metadata,
+        ]));
+
+        return $batchId;
+    }
+
+    /**
+     * Close a batch by ID. Updates the parent row's snapshot with childCount,
+     * durationMs, state ('completed' or 'failed'), and closedAt. Pops from
+     * the stack. Fires EVENT_BATCH_ENDED.
+     *
+     * If $batchId isn't in the stack (e.g., double-close), logs a warning
+     * and returns without raising. If it's not at the top of the stack
+     * (out-of-order close), still closes the targeted batch and logs a
+     * warning.
+     */
+    public function close(int $batchId, array $summary = [], bool $failed = false): void
+    {
+        $idx = array_search($batchId, $this->stack, true);
+        if ($idx === false) {
+            Craft::warning(
+                "BatchService::close(): batch {$batchId} not found in stack (already closed?)",
+                __METHOD__
+            );
+            return;
+        }
+        if ($idx !== count($this->stack) - 1) {
+            Craft::warning(
+                "BatchService::close(): batch {$batchId} closed out of order",
+                __METHOD__
+            );
+        }
+        array_splice($this->stack, $idx, 1);
+
+        // Capture state BEFORE unset — the BatchEndedEvent payload needs the title.
+        $title = $this->state[$batchId]['title'] ?? '';
+        $opened = $this->state[$batchId]['openedAt'] ?? null;
+        unset($this->state[$batchId]);
+
+        $durationMs = $opened !== null ? (int) ((microtime(true) - $opened) * 1000) : null;
+
+        // Count children
+        $childCount = (int) AuditRecord::find()
+            ->where(['parentId' => $batchId])
+            ->count();
+
+        // Load the parent row and update its snapshot + event
+        $parentRecord = AuditRecord::findOne($batchId);
+        if ($parentRecord === null) {
+            Craft::warning(
+                "BatchService::close(): parent record {$batchId} not found",
+                __METHOD__
+            );
+            return;
+        }
+
+        $decoded = Json::decodeIfJson($parentRecord->snapshot);
+        $snapshot = is_array($decoded) ? $decoded : [];
+
+        $state = $failed ? 'failed' : 'completed';
+        $snapshot['state'] = $state;
+        $snapshot['closedAt'] = date('c');
+        $snapshot['durationMs'] = $durationMs;
+        $snapshot['childCount'] = $childCount;
+        $snapshot['summary'] = $summary;
+
+        $parentRecord->event = $failed
+            ? AuditEvent::BatchFailed->value
+            : AuditEvent::BatchCompleted->value;
+        $parentRecord->snapshot = Json::encode($snapshot);
+        $parentRecord->save(false);
+
+        $this->trigger(self::EVENT_BATCH_ENDED, new BatchEndedEvent([
+            'batchId' => $batchId,
+            'title' => $title,
+            'state' => $state,
+            'durationMs' => $durationMs,
+            'childCount' => $childCount,
+            'summary' => $summary,
+        ]));
+    }
+
+    /** Returns the innermost open batch ID, or null if no batch is open. */
+    public function currentBatchId(): ?int
+    {
+        if ($this->stack === []) {
+            return null;
+        }
+        return (int) $this->stack[count($this->stack) - 1];
+    }
+
+    /**
+     * Returns the current stack of open batch IDs (outermost first).
+     * For testing and introspection.
+     *
+     * @return int[]
+     */
+    public function openBatches(): array
+    {
+        return $this->stack;
+    }
+}

--- a/src/translations/en/audit.php
+++ b/src/translations/en/audit.php
@@ -67,4 +67,9 @@ return [
     // Backups
     \superbig\audit\enums\AuditEvent::BackupCreated->value => 'Backup created',
     \superbig\audit\enums\AuditEvent::BackupRestored->value => 'Backup restored',
+
+    // Batch lifecycle
+    \superbig\audit\enums\AuditEvent::BatchStarted->value => 'Batch started',
+    \superbig\audit\enums\AuditEvent::BatchCompleted->value => 'Batch completed',
+    \superbig\audit\enums\AuditEvent::BatchFailed->value => 'Batch failed',
 ];

--- a/tests/Feature/BatchServiceTest.php
+++ b/tests/Feature/BatchServiceTest.php
@@ -1,0 +1,304 @@
+<?php
+
+use superbig\audit\Audit;
+use superbig\audit\enums\AuditEvent;
+use superbig\audit\events\BatchEndedEvent;
+use superbig\audit\events\BatchStartedEvent;
+use superbig\audit\records\AuditRecord;
+use superbig\audit\services\BatchService;
+
+beforeEach(function () {
+    AuditRecord::deleteAll();
+});
+
+it('run() executes the callback, returns its value, and persists one parent row with state=completed', function () {
+    $batch = Audit::$plugin->batch;
+
+    $result = $batch->run('Happy path batch', function () {
+        return 'callback-return-value';
+    });
+
+    expect($result)->toBe('callback-return-value');
+    expect($batch->currentBatchId())->toBeNull();
+
+    $rows = AuditRecord::find()->all();
+    expect($rows)->toHaveCount(1);
+
+    $parent = $rows[0];
+    expect($parent->event)->toBe(AuditEvent::BatchCompleted->value);
+    expect($parent->title)->toBe('Happy path batch');
+
+    $snapshot = json_decode($parent->snapshot, true);
+    expect($snapshot['state'])->toBe('completed');
+    expect($snapshot['childCount'])->toBe(0);
+});
+
+it('run() auto-attaches child records written via auditRecorder->record()', function () {
+    $batch = Audit::$plugin->batch;
+
+    $capturedBatchId = null;
+    $batch->run('Auto-attach test', function () use (&$capturedBatchId, $batch) {
+        $capturedBatchId = $batch->currentBatchId();
+        Audit::$plugin->auditRecorder->record(
+            event: AuditEvent::EntrySaved,
+            title: 'Child A',
+        );
+        Audit::$plugin->auditRecorder->record(
+            event: AuditEvent::EntrySaved,
+            title: 'Child B',
+        );
+    });
+
+    expect($capturedBatchId)->not->toBeNull();
+
+    $children = AuditRecord::find()
+        ->where(['parentId' => $capturedBatchId])
+        ->all();
+    expect($children)->toHaveCount(2);
+    foreach ($children as $child) {
+        expect((int) $child->parentId)->toBe($capturedBatchId);
+    }
+});
+
+it('run() with exception marks batch as failed and re-throws', function () {
+    $batch = Audit::$plugin->batch;
+
+    $batchIdSeen = null;
+
+    expect(function () use ($batch, &$batchIdSeen) {
+        $batch->run('Failing batch', function () use ($batch, &$batchIdSeen) {
+            $batchIdSeen = $batch->currentBatchId();
+            throw new \RuntimeException('boom');
+        });
+    })->toThrow(\RuntimeException::class, 'boom');
+
+    expect($batchIdSeen)->not->toBeNull();
+    expect($batch->currentBatchId())->toBeNull();
+
+    $parent = AuditRecord::findOne($batchIdSeen);
+    expect($parent)->not->toBeNull();
+    expect($parent->event)->toBe(AuditEvent::BatchFailed->value);
+
+    $snapshot = json_decode($parent->snapshot, true);
+    expect($snapshot['state'])->toBe('failed');
+});
+
+it('open() + close() manual lifecycle works and auto-attaches in between', function () {
+    $batch = Audit::$plugin->batch;
+
+    $id = $batch->open('Manual batch');
+    expect($id)->toBeInt();
+    expect($id)->toBeGreaterThan(0);
+    expect($batch->currentBatchId())->toBe($id);
+
+    Audit::$plugin->auditRecorder->record(
+        event: AuditEvent::EntrySaved,
+        title: 'Child inside manual batch',
+    );
+
+    $batch->close($id);
+    expect($batch->currentBatchId())->toBeNull();
+
+    $children = AuditRecord::find()->where(['parentId' => $id])->all();
+    expect($children)->toHaveCount(1);
+
+    $parent = AuditRecord::findOne($id);
+    expect($parent->event)->toBe(AuditEvent::BatchCompleted->value);
+});
+
+it('currentBatchId() returns null when nothing is open', function () {
+    expect(Audit::$plugin->batch->currentBatchId())->toBeNull();
+    expect(Audit::$plugin->batch->openBatches())->toBe([]);
+});
+
+it('nested batches inherit parentId and child records attach to innermost', function () {
+    $batch = Audit::$plugin->batch;
+
+    $outerId = $batch->open('Outer');
+
+    Audit::$plugin->auditRecorder->record(
+        event: AuditEvent::EntrySaved,
+        title: 'Direct outer child',
+    );
+
+    $innerId = $batch->open('Inner');
+
+    // Inner's parent row should point at outer
+    $innerRow = AuditRecord::findOne($innerId);
+    expect((int) $innerRow->parentId)->toBe($outerId);
+
+    // Record inside inner — should attach to inner, not outer
+    Audit::$plugin->auditRecorder->record(
+        event: AuditEvent::EntrySaved,
+        title: 'Inner child',
+    );
+
+    expect($batch->currentBatchId())->toBe($innerId);
+
+    $batch->close($innerId);
+    expect($batch->currentBatchId())->toBe($outerId);
+
+    // After inner closes, records attach back to outer
+    Audit::$plugin->auditRecorder->record(
+        event: AuditEvent::EntrySaved,
+        title: 'Back-to-outer child',
+    );
+
+    $batch->close($outerId);
+
+    $innerChildren = AuditRecord::find()->where(['parentId' => $innerId])->all();
+    expect($innerChildren)->toHaveCount(1);
+    expect($innerChildren[0]->title)->toBe('Inner child');
+
+    $outerChildren = AuditRecord::find()->where(['parentId' => $outerId])->all();
+    // outer has: direct outer child + inner batch row + back-to-outer child = 3
+    expect($outerChildren)->toHaveCount(3);
+});
+
+it('close() with an unknown batch id is a no-op and logs a warning', function () {
+    $batch = Audit::$plugin->batch;
+
+    // Open A then B; close A out of order.
+    $a = $batch->open('A');
+    $b = $batch->open('B');
+
+    // Out-of-order close — should still work, B stays open.
+    $batch->close($a);
+    expect($batch->currentBatchId())->toBe($b);
+
+    $batch->close($b);
+    expect($batch->currentBatchId())->toBeNull();
+
+    // Both parent rows exist and are marked completed.
+    $aRow = AuditRecord::findOne($a);
+    $bRow = AuditRecord::findOne($b);
+    expect($aRow->event)->toBe(AuditEvent::BatchCompleted->value);
+    expect($bRow->event)->toBe(AuditEvent::BatchCompleted->value);
+});
+
+it('close() populates childCount and durationMs in the parent snapshot', function () {
+    $batch = Audit::$plugin->batch;
+
+    $id = $batch->open('Counted batch');
+    Audit::$plugin->auditRecorder->record(event: AuditEvent::EntrySaved, title: '1');
+    Audit::$plugin->auditRecorder->record(event: AuditEvent::EntrySaved, title: '2');
+    Audit::$plugin->auditRecorder->record(event: AuditEvent::EntrySaved, title: '3');
+    $batch->close($id);
+
+    $parent = AuditRecord::findOne($id);
+    $snapshot = json_decode($parent->snapshot, true);
+
+    expect($snapshot['childCount'])->toBe(3);
+    expect($snapshot['durationMs'])->toBeInt();
+    expect($snapshot['durationMs'])->toBeGreaterThanOrEqual(0);
+    expect($snapshot)->toHaveKey('closedAt');
+    expect($snapshot)->toHaveKey('summary');
+});
+
+it('close() carries the supplied summary into the snapshot', function () {
+    $batch = Audit::$plugin->batch;
+
+    $id = $batch->open('With summary');
+    $batch->close($id, summary: ['processed' => 42, 'errors' => 0]);
+
+    $parent = AuditRecord::findOne($id);
+    $snapshot = json_decode($parent->snapshot, true);
+    expect($snapshot['summary'])->toBe(['processed' => 42, 'errors' => 0]);
+});
+
+it('EVENT_BATCH_STARTED fires with batchId, title, and metadata', function () {
+    $batch = Audit::$plugin->batch;
+
+    $captured = null;
+    $batch->on(BatchService::EVENT_BATCH_STARTED, function (BatchStartedEvent $event) use (&$captured) {
+        $captured = [
+            'batchId' => $event->batchId,
+            'title' => $event->title,
+            'metadata' => $event->metadata,
+        ];
+    });
+
+    $id = $batch->open('Started event test', ['key' => 'value']);
+    $batch->close($id);
+
+    expect($captured)->not->toBeNull();
+    expect($captured['batchId'])->toBe($id);
+    expect($captured['title'])->toBe('Started event test');
+    expect($captured['metadata'])->toBe(['key' => 'value']);
+
+    $batch->off(BatchService::EVENT_BATCH_STARTED);
+});
+
+it('EVENT_BATCH_ENDED fires with state=completed for success and state=failed for exception', function () {
+    $batch = Audit::$plugin->batch;
+
+    $captured = [];
+    $listener = function (BatchEndedEvent $event) use (&$captured) {
+        $captured[] = [
+            'batchId' => $event->batchId,
+            'title' => $event->title,
+            'state' => $event->state,
+            'childCount' => $event->childCount,
+            'durationMs' => $event->durationMs,
+        ];
+    };
+    $batch->on(BatchService::EVENT_BATCH_ENDED, $listener);
+
+    $batch->run('Happy ended', fn () => null);
+
+    try {
+        $batch->run('Failing ended', function () {
+            throw new \RuntimeException('x');
+        });
+    } catch (\RuntimeException) {
+        // expected
+    }
+
+    $batch->off(BatchService::EVENT_BATCH_ENDED, $listener);
+
+    expect($captured)->toHaveCount(2);
+    expect($captured[0]['state'])->toBe('completed');
+    expect($captured[0]['title'])->toBe('Happy ended');
+    expect($captured[1]['state'])->toBe('failed');
+    expect($captured[1]['title'])->toBe('Failing ended');
+});
+
+it('explicit parentId override beats batch auto-attach', function () {
+    $batch = Audit::$plugin->batch;
+
+    // Create a standalone record we can point at.
+    $standalone = Audit::$plugin->auditRecorder->record(
+        event: AuditEvent::EntrySaved,
+        title: 'Standalone',
+    );
+    $standaloneId = (int) $standalone->id;
+
+    $batchId = $batch->open('Override test');
+    $child = Audit::$plugin->auditRecorder->record(
+        event: AuditEvent::EntrySaved,
+        title: 'Explicitly parented',
+        overrides: ['parentId' => $standaloneId],
+    );
+    $batch->close($batchId);
+
+    expect((int) $child->parentId)->toBe($standaloneId);
+    expect((int) $child->parentId)->not->toBe($batchId);
+});
+
+it('close() is idempotent — second close on the same id is a no-op', function () {
+    $batch = Audit::$plugin->batch;
+
+    $id = $batch->open('Idempotent close');
+    $batch->close($id);
+
+    $parentAfterFirst = AuditRecord::findOne($id);
+    $snapshotAfterFirst = $parentAfterFirst->snapshot;
+    $eventAfterFirst = $parentAfterFirst->event;
+
+    // Second close should warn-and-return; no side effects, no exception.
+    $batch->close($id);
+
+    $parentAfterSecond = AuditRecord::findOne($id);
+    expect($parentAfterSecond->event)->toBe($eventAfterFirst);
+    expect($parentAfterSecond->snapshot)->toBe($snapshotAfterFirst);
+});

--- a/tests/Feature/EnumCoverageTest.php
+++ b/tests/Feature/EnumCoverageTest.php
@@ -2,10 +2,10 @@
 
 use superbig\audit\enums\AuditEvent;
 
-it('has 69 unique kebab-case backing values', function () {
+it('has 72 unique kebab-case backing values', function () {
     $values = array_map(fn ($c) => $c->value, AuditEvent::cases());
-    expect(count($values))->toBe(69);
-    expect(count(array_unique($values)))->toBe(69);
+    expect(count($values))->toBe(72);
+    expect(count(array_unique($values)))->toBe(72);
     foreach ($values as $v) {
         expect($v)->toMatch('/^[a-z]+(-[a-z]+)*$/');
     }
@@ -31,9 +31,9 @@ it('tryFromString resolves existing events', function () {
     expect(AuditEvent::tryFromString('saved-element'))->toBe(AuditEvent::SavedElement);
 });
 
-it('has 69 total cases (45 original + 24 project config)', function () {
+it('has 72 total cases (45 original + 24 project config + 3 batch lifecycle)', function () {
     $count = count(AuditEvent::cases());
-    expect($count)->toBe(69);
+    expect($count)->toBe(72);
 });
 
 it('returns a translated label for each case', function () {


### PR DESCRIPTION
## P3.1: BatchService foundation — open/close/run API for grouping audit rows

Adds `BatchService`, the core infrastructure for grouping related audit rows under a parent record. A "batch" is an audit row with event `BatchStarted`/`BatchCompleted`/`BatchFailed` that acts as a parent for all rows recorded while the batch is open. The service is the foundation for P3.2 (ResaveElements), P3.3 (CP UI), and P3.4 (Feed Me).

Auto-attachment is wired into `AuditRecorder::record()`: after the overrides loop and before `EVENT_BEFORE_RECORD`, if `BatchService::currentBatchId()` is non-null and `$record->parentId` is null, the recorder sets the parent automatically. Callers don't need to know about batches — any audit row recorded while a batch is open inherits the parent ID.

### What changed

- **`src/services/BatchService.php`** (new, 243 LOC) — `open(string $title, array $metadata = [])` opens a batch and returns its ID; `close(int $batchId, ?string $summary, bool $failed)` closes it; `run(string $title, callable $callback)` wraps open/close around a callback; `currentBatchId()` returns the active batch ID or null.
- **`src/events/BatchStartedEvent.php`** (new, 20 LOC) — event fired after a batch row is persisted. Observational only (not cancellable).
- **`src/events/BatchEndedEvent.php`** (new, 25 LOC) — event fired after a batch is closed. Carries `$failed` flag.
- **`src/enums/AuditEvent.php`** (+5 LOC) — adds `BatchStarted`, `BatchCompleted`, `BatchFailed` cases.
- **`src/services/AuditRecorder.php`** (+9 LOC) — auto-attach hook: sets `$record->parentId` from `currentBatchId()` when not already set.
- **`src/Audit.php`** (+3 LOC) — registers `BatchService` in the service container.
- **`src/translations/en/audit.php`** (+5 entries) — batch state labels.
- **`tests/Feature/BatchServiceTest.php`** (new, 304 LOC, +13 tests) — covers open/close/run, auto-attach, nested batch behavior, event firing, and failure path.
- **`tests/Feature/EnumCoverageTest.php`** — updated to include the 3 new enum cases.

### Tests

- +13 tests, +BatchService coverage
- ECS clean
- PHPStan clean
- Fresh-DB green

### Stacked on

`p2.9-real-api-tests` (#115)
