### PR TITLE
P3.2: migrate ResaveElements to BatchService — kills cache-key concurrency bug

### DIFF
--- a/src/Audit.php
+++ b/src/Audit.php
@@ -245,7 +245,7 @@ class Audit extends Plugin
             Queue::EVENT_AFTER_ERROR,
             function(ExecEvent $event) {
                 if ($event->job instanceof ResaveElements) {
-                    $this->elementHandler->onResaveEnd($event->job);
+                    $this->elementHandler->onResaveEnd($event->job, failed: true);
                 }
             }
         );

--- a/src/models/AuditModel.php
+++ b/src/models/AuditModel.php
@@ -22,8 +22,6 @@ use Throwable;
 
 class AuditModel extends Model
 {
-    public const FLASH_RESAVE_ID = 'auditResaveId';
-
     private static $_users;
 
     /**

--- a/src/services/AuditRecorder.php
+++ b/src/services/AuditRecorder.php
@@ -208,6 +208,13 @@ class AuditRecorder extends Component
      */
     public function saveRecord(AuditModel &$model, bool $unique = true): bool
     {
+        // Auto-attach to the currently-open batch if no parentId was set explicitly.
+        // Mirrors the same hook in record(); needed because the 8 handler services
+        // still use getStandardModel() + saveRecord() rather than record().
+        if ($model->parentId === null) {
+            $model->parentId = Audit::$plugin->batch->currentBatchId();
+        }
+
         try {
             if ($model->id) {
                 $record = AuditRecord::findOne($model->id);

--- a/src/services/handlers/ElementHandler.php
+++ b/src/services/handlers/ElementHandler.php
@@ -14,7 +14,6 @@ use craft\helpers\Html;
 use craft\queue\jobs\ResaveElements;
 use superbig\audit\Audit;
 use superbig\audit\enums\AuditEvent;
-use superbig\audit\models\AuditModel;
 
 /**
  * ElementHandler — handles element-related audit events extracted from AuditService.
@@ -24,6 +23,17 @@ use superbig\audit\models\AuditModel;
  */
 class ElementHandler extends Component
 {
+    /**
+     * Map of spl_object_id($job) → batchId for in-flight resave jobs.
+     *
+     * Replaces the legacy cache-keyed-by-element-type pattern (FRE-140), which
+     * collided when two queue workers ran the same element type concurrently.
+     * Per-job-instance keys make collisions impossible.
+     *
+     * @var array<int, int>
+     */
+    private array $resaveBatchIds = [];
+
     /**
      * @param ElementInterface $element
      * @param bool $isNew
@@ -131,11 +141,6 @@ class ElementHandler extends Component
             }
 
             $model->snapshot = $auditRecorder->afterSnapshot($model, array_merge($model->snapshot, $snapshot));
-            $parentId = $this->getParentId($model->elementType);
-
-            if (!empty($parentId)) {
-                $model->parentId = $parentId;
-            }
 
             return $auditRecorder->saveRecord($model);
         } catch (\Exception $e) {
@@ -214,26 +219,27 @@ class ElementHandler extends Component
         }
     }
 
+    /**
+     * Opens an audit batch for the resave job. Any audit rows written while
+     * the queue worker processes elements inherit the batch as their parent
+     * via AuditRecorder's auto-attach hook.
+     *
+     * @internal Wired from \superbig\audit\Audit::setupQueueEvents().
+     */
     public function onBeforeResave(ResaveElements $job): bool
     {
-        $auditRecorder = Audit::$plugin->auditRecorder;
-
         try {
-            $model = $auditRecorder->getStandardModel();
-            $model->event = AuditEvent::ResavedElements->value;
-            $model->elementType = $job->elementType;
-            $model->appendSnapshot('resaveCriteria', $job->criteria);
-
-            $auditRecorder->saveRecord($model);
-
-            if ($model->id) {
-                $parentIdKey = $this->getParentIdKey($job->elementType);
-
-                Craft::$app->getCache()->set($parentIdKey, $model->id);
-            }
-        } catch (\Exception $e) {
+            $batchId = Audit::$plugin->batch->open(
+                title: 'Resaving ' . $job->elementType . ' elements',
+                metadata: [
+                    'elementType' => $job->elementType,
+                    'criteria' => $job->criteria,
+                ],
+            );
+            $this->resaveBatchIds[spl_object_id($job)] = $batchId;
+        } catch (\Throwable $e) {
             Craft::error(
-                Craft::t('audit', 'Error when logging: {error}', ['error' => $e->getMessage()]),
+                'Audit: failed to open resave batch — ' . $e->getMessage(),
                 __METHOD__
             );
         }
@@ -242,54 +248,30 @@ class ElementHandler extends Component
     }
 
     /**
-     * @param string $elementType
+     * Closes the batch opened by {@see onBeforeResave()}. Idempotent and safe
+     * to call without a prior open() (e.g., if open() itself failed).
      *
-     * @return mixed
+     * @internal Wired from \superbig\audit\Audit::setupQueueEvents().
      */
-    public function getParentId(string $elementType = ''): mixed
+    public function onResaveEnd(ResaveElements $job, bool $failed = false): mixed
     {
-        $cache = Craft::$app->getCache();
-        $parentId = $cache->get($this->getParentIdKey($elementType));
+        $key = spl_object_id($job);
+        if (!isset($this->resaveBatchIds[$key])) {
+            return true;
+        }
 
-        return $parentId;
-    }
-
-    /**
-     * @param ResaveElements $job
-     *
-     * @return mixed
-     */
-    public function onResaveEnd(ResaveElements $job): mixed
-    {
-        $auditService = Audit::$plugin->auditService;
-        $auditRecorder = Audit::$plugin->auditRecorder;
+        $batchId = $this->resaveBatchIds[$key];
+        unset($this->resaveBatchIds[$key]);
 
         try {
-            $cache = Craft::$app->getCache();
-            $parentKey = $this->getParentIdKey($job->elementType);
-            $parentId = $cache->get($parentKey);
-
-            if ($parentId) {
-                $parentEvent = $auditService->getEventById((int) $parentId);
-                $subEventCount = $auditService->getEventCountByParentId((int) $parentId);
-
-                if ($parentEvent) {
-                    $parentEvent->title = $subEventCount . ' elements was re-saved';
-
-                    $auditRecorder->saveRecord($parentEvent);
-                }
-
-                $cache->delete($parentKey);
-            }
-        } catch (\Exception $e) {
-            Craft::error('Failed to remove resave id: ' . $e->getMessage(), __METHOD__);
+            Audit::$plugin->batch->close($batchId, failed: $failed);
+        } catch (\Throwable $e) {
+            Craft::error(
+                'Audit: failed to close resave batch — ' . $e->getMessage(),
+                __METHOD__
+            );
         }
 
         return true;
-    }
-
-    public function getParentIdKey($elementType = ''): string
-    {
-        return AuditModel::FLASH_RESAVE_ID . ':' . $elementType;
     }
 }

--- a/tests/Feature/ResaveElementsIntegrationTest.php
+++ b/tests/Feature/ResaveElementsIntegrationTest.php
@@ -1,0 +1,223 @@
+<?php
+
+use craft\elements\Entry;
+use craft\queue\jobs\ResaveElements;
+use superbig\audit\Audit;
+use superbig\audit\enums\AuditEvent;
+use superbig\audit\records\AuditRecord;
+
+beforeEach(function () {
+    AuditRecord::deleteAll();
+});
+
+/**
+ * Build a fake ResaveElements job we can pass to ElementHandler.
+ *
+ * We never run() the job — we only use its instance identity and a couple of
+ * public properties (elementType, criteria) that ElementHandler reads.
+ */
+function makeResaveJob(string $elementType = Entry::class, array $criteria = []): ResaveElements
+{
+    $job = new ResaveElements();
+    $job->elementType = $elementType;
+    $job->criteria = $criteria;
+    return $job;
+}
+
+it('onBeforeResave opens a batch and exposes the batch id via currentBatchId()', function () {
+    $handler = Audit::$plugin->elementHandler;
+    $batch = Audit::$plugin->batch;
+
+    expect($batch->currentBatchId())->toBeNull();
+
+    $job = makeResaveJob(Entry::class, ['sectionId' => 1]);
+    $handler->onBeforeResave($job);
+
+    $batchId = $batch->currentBatchId();
+    expect($batchId)->toBeInt();
+    expect($batchId)->toBeGreaterThan(0);
+
+    $parent = AuditRecord::findOne($batchId);
+    expect($parent)->not->toBeNull();
+    expect($parent->event)->toBe(AuditEvent::BatchStarted->value);
+
+    // Clean up so the next test starts with an empty stack
+    $handler->onResaveEnd($job);
+});
+
+it('saveRecord() inside an open resave batch auto-attaches the child to the batch', function () {
+    $handler = Audit::$plugin->elementHandler;
+    $recorder = Audit::$plugin->auditRecorder;
+    $batch = Audit::$plugin->batch;
+
+    $job = makeResaveJob(Entry::class, ['sectionId' => 1]);
+    $handler->onBeforeResave($job);
+    $batchId = $batch->currentBatchId();
+
+    // Write a child row via the legacy getStandardModel() + saveRecord() path.
+    // This is the API every handler service still uses, and it MUST inherit
+    // parentId from the open batch via the auto-attach hook.
+    $model = $recorder->getStandardModel();
+    $model->event = AuditEvent::EntrySaved->value;
+    $model->title = 'Child entry';
+    $recorder->saveRecord($model);
+
+    expect($model->id)->not->toBeNull();
+    $childRow = AuditRecord::findOne($model->id);
+    expect((int) $childRow->parentId)->toBe($batchId);
+
+    $handler->onResaveEnd($job);
+});
+
+it('onResaveEnd closes the batch — parent row is marked completed with childCount', function () {
+    $handler = Audit::$plugin->elementHandler;
+    $recorder = Audit::$plugin->auditRecorder;
+    $batch = Audit::$plugin->batch;
+
+    $job = makeResaveJob(Entry::class, ['sectionId' => 1]);
+    $handler->onBeforeResave($job);
+    $batchId = $batch->currentBatchId();
+
+    // Write two children so childCount has something interesting to report.
+    foreach (['one', 'two'] as $title) {
+        $model = $recorder->getStandardModel();
+        $model->event = AuditEvent::EntrySaved->value;
+        $model->title = $title;
+        $recorder->saveRecord($model);
+    }
+
+    $handler->onResaveEnd($job);
+
+    expect($batch->currentBatchId())->toBeNull();
+
+    $parent = AuditRecord::findOne($batchId);
+    expect($parent->event)->toBe(AuditEvent::BatchCompleted->value);
+
+    $snapshot = json_decode($parent->snapshot, true);
+    expect($snapshot['state'])->toBe('completed');
+    expect($snapshot['childCount'])->toBe(2);
+});
+
+it('onResaveEnd(failed: true) closes the batch with state=failed', function () {
+    $handler = Audit::$plugin->elementHandler;
+    $batch = Audit::$plugin->batch;
+
+    $job = makeResaveJob(Entry::class, ['sectionId' => 1]);
+    $handler->onBeforeResave($job);
+    $batchId = $batch->currentBatchId();
+
+    $handler->onResaveEnd($job, failed: true);
+
+    $parent = AuditRecord::findOne($batchId);
+    expect($parent->event)->toBe(AuditEvent::BatchFailed->value);
+
+    $snapshot = json_decode($parent->snapshot, true);
+    expect($snapshot['state'])->toBe('failed');
+});
+
+it('concurrent resave jobs of the same element type do not collide (FRE-140 regression)', function () {
+    $handler = Audit::$plugin->elementHandler;
+    $recorder = Audit::$plugin->auditRecorder;
+    $batch = Audit::$plugin->batch;
+
+    // Two distinct ResaveElements instances targeting the same element type.
+    // Under the legacy cache-key pattern, both would share the key
+    // 'auditResaveId:craft\elements\Entry' and the second job's open()
+    // would overwrite the first job's parent id in cache. Children written
+    // after that overwrite would attach to the wrong parent.
+    $jobA = makeResaveJob(Entry::class, ['sectionId' => 1]);
+    $jobB = makeResaveJob(Entry::class, ['sectionId' => 2]);
+
+    $handler->onBeforeResave($jobA);
+    $batchA = $batch->currentBatchId();
+
+    // Interleave: open B while A is still open, write children under each,
+    // and close in LIFO order. This exercises both per-instance isolation
+    // AND the BatchService stack semantics.
+    $handler->onBeforeResave($jobB);
+    $batchB = $batch->currentBatchId();
+
+    expect($batchA)->not->toBe($batchB);
+
+    // While B is the innermost open batch, a child written via saveRecord()
+    // should attach to B (not A).
+    $childB = $recorder->getStandardModel();
+    $childB->event = AuditEvent::EntrySaved->value;
+    $childB->title = 'belongs-to-B';
+    $recorder->saveRecord($childB);
+
+    // Close B — A is now the innermost open batch.
+    $handler->onResaveEnd($jobB);
+    expect($batch->currentBatchId())->toBe($batchA);
+
+    // A child written now should attach to A.
+    $childA = $recorder->getStandardModel();
+    $childA->event = AuditEvent::EntrySaved->value;
+    $childA->title = 'belongs-to-A';
+    $recorder->saveRecord($childA);
+
+    $handler->onResaveEnd($jobA);
+    expect($batch->currentBatchId())->toBeNull();
+
+    // Verify the children attached to the correct parents — the heart of
+    // FRE-140. Under the bug, both children would have ended up under the
+    // same (wrong) parent.
+    $childARow = AuditRecord::findOne($childA->id);
+    $childBRow = AuditRecord::findOne($childB->id);
+    expect((int) $childARow->parentId)->toBe($batchA);
+    expect((int) $childBRow->parentId)->toBe($batchB);
+
+    // And both parent rows closed cleanly with childCount=1 each.
+    $parentA = AuditRecord::findOne($batchA);
+    $parentB = AuditRecord::findOne($batchB);
+    expect($parentA->event)->toBe(AuditEvent::BatchCompleted->value);
+    expect($parentB->event)->toBe(AuditEvent::BatchCompleted->value);
+
+    // A's children: B's batch parent row (nested) + childA = 2.
+    // B's children: just childB = 1.
+    // The important thing for FRE-140 is that childA and childB attached to
+    // the *correct* parent above; the childCount values are a bonus check on
+    // nested-batch accounting.
+    expect(json_decode($parentA->snapshot, true)['childCount'])->toBe(2);
+    expect(json_decode($parentB->snapshot, true)['childCount'])->toBe(1);
+});
+
+it('onResaveEnd is idempotent — calling it twice is a safe no-op', function () {
+    $handler = Audit::$plugin->elementHandler;
+    $batch = Audit::$plugin->batch;
+
+    $job = makeResaveJob(Entry::class, ['sectionId' => 1]);
+    $handler->onBeforeResave($job);
+    $batchId = $batch->currentBatchId();
+
+    $handler->onResaveEnd($job);
+    $parentAfterFirst = AuditRecord::findOne($batchId);
+    $snapshotAfterFirst = $parentAfterFirst->snapshot;
+    $eventAfterFirst = $parentAfterFirst->event;
+
+    // Second close — the lookup table no longer has the entry, so this
+    // returns true without ever calling BatchService::close(). No exception.
+    $result = $handler->onResaveEnd($job);
+    expect($result)->toBeTrue();
+
+    $parentAfterSecond = AuditRecord::findOne($batchId);
+    expect($parentAfterSecond->event)->toBe($eventAfterFirst);
+    expect($parentAfterSecond->snapshot)->toBe($snapshotAfterFirst);
+});
+
+it('onResaveEnd without a prior onBeforeResave is a safe no-op', function () {
+    $handler = Audit::$plugin->elementHandler;
+    $batch = Audit::$plugin->batch;
+
+    $job = makeResaveJob(Entry::class, ['sectionId' => 1]);
+
+    // No onBeforeResave call. Closing should return cleanly without
+    // touching the batch stack or raising an exception.
+    $result = $handler->onResaveEnd($job);
+
+    expect($result)->toBeTrue();
+    expect($batch->currentBatchId())->toBeNull();
+
+    // No audit records should have been written.
+    expect((int) AuditRecord::find()->count())->toBe(0);
+});


### PR DESCRIPTION
## P3.2: migrate ResaveElements to BatchService, fix parallel-job parent-ID collision

Rewrites `ElementHandler`'s resave-batch tracking to use `BatchService` instead of the in-process `parent_id` cache. The old cache was keyed by element type (`Entry`, `Asset`, etc.), so two parallel `ResaveElements` queue jobs for the same element type would clobber each other's parent IDs — every element saved by job B would be parented to job A's batch row (FRE-140).

The fix: `ElementHandler` now calls `BatchService::open()` at `onBeforeResave` and `BatchService::close()` at `onResaveEnd`, keying the batch ID by `spl_object_id($job)` on a private `$resaveBatchIds[]` property. Each job instance gets its own batch, regardless of element type. `onResaveEnd` gains a `bool $failed` parameter passed by `Queue::EVENT_AFTER_ERROR` so failed resave jobs close their batch with the failure flag set.

A second auto-attach hook is added in `AuditRecorder::saveRecord()` (the lower-level write path) so all 8 handler services inherit batch parentage — not just the ones that go through `record()`.

### What changed

- **`src/services/handlers/ElementHandler.php`** (+44/-62) — replaces `getParentId()`/`getParentIdKey()`/`FLASH_RESAVE_ID` with `BatchService::open()`/`close()` calls. Adds `private array $resaveBatchIds = []` keyed by `spl_object_id($job)`. `onResaveEnd` gains `bool $failed = false` parameter.
- **`src/services/AuditRecorder.php`** (+7 LOC) — second auto-attach hook in `saveRecord()` mirrors the one in `record()`.
- **`src/models/AuditModel.php`** (-2 LOC) — removes `FLASH_RESAVE_ID` constant (now deleted).
- **`src/Audit.php`** (+1/-1) — minor service-container update.
- **`tests/Feature/ResaveElementsIntegrationTest.php`** (new, 223 LOC, +7 tests) — covers single-job batch grouping, parallel-job isolation (two concurrent resave jobs don't cross-contaminate parent IDs), failed-job batch closure, and the `saveRecord()` auto-attach path.

### Tests

- +7 tests
- ECS clean
- PHPStan clean
- Fresh-DB green

### Stacked on

`p3.1-batch-api-foundation` (#116)
