### PR TITLE
ci: bump test fixture schemaVersion to match Craft 5.10.0.0

### DIFF
--- a/stubs/project/project.yaml
+++ b/stubs/project/project.yaml
@@ -34,7 +34,7 @@ system:
   edition: pro
   live: true
   name: 'Craft Audit'
-  schemaVersion: 5.9.0.8
+  schemaVersion: 5.10.0.0
   timeZone: Europe/Amsterdam
 users:
   allowPublicRegistration: false


### PR DESCRIPTION
Craft CMS 5.10 was released with schemaVersion `5.10.0.0`. Our CI installs the latest 5.x via:

```
composer require craftcms/cms:^5.5
```

…so the stub project.yaml's pin at `5.9.0.8` now fails project config validation on install:

> Project config validation failed: Craft CMS is Composer-installed with schema version 5.10.0.0, but project.yaml expects 5.9.0.8.

This affects **every PR CI'd after Craft 5.10 shipped** (PRs #90–#99 are still green because they ran before the release; #116 and #117 went red). Unrelated to plugin code.

Once this lands on `v3`, the existing stack of PRs will pick up the fix on rebase and CI will go green again.