### PR TITLE
P3.4: Feed Me bake-in — auto-batch each feed import via EVENT_BEFORE/AFTER_PROCESS_FEED

### DIFF
--- a/src/Audit.php
+++ b/src/Audit.php
@@ -59,6 +59,7 @@ use superbig\audit\services\AuditRecorder;
 use superbig\audit\services\AuditService;
 use superbig\audit\services\BatchService;
 use superbig\audit\services\DiffRenderer;
+use superbig\audit\services\FeedMeListener;
 use superbig\audit\services\FieldDiffService;
 use superbig\audit\services\FieldHandlerRegistry;
 use superbig\audit\services\handlers\BackupHandler;
@@ -94,6 +95,7 @@ use yii\web\UserEvent;
  * @property  PluginHandler         $pluginHandler
  * @property  SettingsHandler       $settingsHandler
  * @property  BatchService          $batch
+ * @property  FeedMeListener        $feedMeListener
  * @method  Settings getSettings()
  */
 class Audit extends Plugin
@@ -158,7 +160,14 @@ class Audit extends Plugin
             'pluginHandler' => PluginHandler::class,
             'settingsHandler' => SettingsHandler::class,
             'batch' => BatchService::class,
+            'feedMeListener' => FeedMeListener::class,
         ]);
+
+        // Eagerly initialize the Feed Me listener — its init() registers an
+        // EVENT_AFTER_LOAD_PLUGINS handler that wires up Feed Me's process
+        // events. Yii lazy-loads components on first access, so we touch it
+        // here to force boot.
+        $this->get('feedMeListener');
 
         $this->registerFieldHandlers();
         $this->projectConfigTracker->register();

--- a/src/services/FeedMeListener.php
+++ b/src/services/FeedMeListener.php
@@ -1,0 +1,170 @@
+<?php
+
+namespace superbig\audit\services;
+
+use Craft;
+use craft\services\Plugins;
+use superbig\audit\Audit;
+use Throwable;
+use yii\base\Component;
+use yii\base\Event;
+
+/**
+ * Wraps each Feed Me feed import in an Audit batch.
+ *
+ * When Feed Me is installed, the BEFORE/AFTER feed-process events open and
+ * close a {@see BatchService} batch, so all audit rows produced by Feed Me's
+ * element saves inherit the batch's parentId via the AuditRecorder auto-attach
+ * hook.
+ *
+ * When Feed Me is NOT installed, this listener registers nothing — no errors,
+ * no warnings, no perf impact.
+ *
+ * Pagination wrinkle: Feed Me's BEFORE and AFTER events may fire in different
+ * queue jobs / different PHP processes. We therefore persist the batch ID in
+ * Craft's cache (keyed by feed ID) rather than an in-memory property.
+ */
+class FeedMeListener extends Component
+{
+    /**
+     * Feed Me's Process service FQCN. String literal so PHPStan won't try to
+     * resolve the class when Feed Me isn't installed.
+     */
+    private const FEED_ME_PROCESS_CLASS = 'craft\\feedme\\services\\Process';
+
+    /**
+     * Feed Me's FeedProcessEvent FQCN — only used as a string-existence probe.
+     */
+    private const FEED_ME_EVENT_CLASS = 'craft\\feedme\\events\\FeedProcessEvent';
+
+    /** Matches Process::EVENT_BEFORE_PROCESS_FEED */
+    private const EVENT_BEFORE_PROCESS_FEED = 'onBeforeProcessFeed';
+
+    /** Matches Process::EVENT_AFTER_PROCESS_FEED */
+    private const EVENT_AFTER_PROCESS_FEED = 'onAfterProcessFeed';
+
+    /** 24-hour cache TTL — far longer than any sane feed import. */
+    private const CACHE_TTL = 86400;
+
+    /**
+     * Defers listener registration until {@see Plugins::EVENT_AFTER_LOAD_PLUGINS}
+     * so Feed Me's classes are guaranteed to be available before we probe for them.
+     */
+    public function init(): void
+    {
+        parent::init();
+
+        Event::on(
+            Plugins::class,
+            Plugins::EVENT_AFTER_LOAD_PLUGINS,
+            function() {
+                if (!$this->feedMeAvailable()) {
+                    return;
+                }
+                $this->register();
+            }
+        );
+    }
+
+    /**
+     * Whether Feed Me's Process service and event class are both available.
+     */
+    public function feedMeAvailable(): bool
+    {
+        return class_exists(self::FEED_ME_PROCESS_CLASS)
+            && class_exists(self::FEED_ME_EVENT_CLASS);
+    }
+
+    /**
+     * Register the BEFORE/AFTER listeners on Feed Me's Process service class.
+     */
+    protected function register(): void
+    {
+        Event::on(
+            self::FEED_ME_PROCESS_CLASS,
+            self::EVENT_BEFORE_PROCESS_FEED,
+            function(Event $event) {
+                $this->onBeforeProcessFeed($event);
+            }
+        );
+
+        Event::on(
+            self::FEED_ME_PROCESS_CLASS,
+            self::EVENT_AFTER_PROCESS_FEED,
+            function(Event $event) {
+                $this->onAfterProcessFeed($event);
+            }
+        );
+    }
+
+    /**
+     * Open a batch when Feed Me starts processing a feed.
+     *
+     * Reads $event->feed defensively — the listener accepts any event object
+     * with a `feed` property exposing `id`, `name`, `elementType`. Errors
+     * are caught and logged so we never throw back into Feed Me.
+     */
+    public function onBeforeProcessFeed(Event $event): void
+    {
+        try {
+            $feed = $event->feed ?? null;
+            if ($feed === null || !isset($feed->id)) {
+                return;
+            }
+            $feedId = (int) $feed->id;
+            $feedName = (string) ($feed->name ?? 'feed');
+            $elementType = (string) ($feed->elementType ?? '');
+
+            $batchId = Audit::$plugin->batch->open(
+                title: 'Feed Me: ' . $feedName,
+                metadata: [
+                    'source' => 'feed-me',
+                    'feedId' => $feedId,
+                    'feedName' => $feedName,
+                    'elementType' => $elementType,
+                ],
+            );
+
+            // Persist for the AFTER listener — may run in a different PHP
+            // process if the feed paginates.
+            Craft::$app->getCache()->set($this->cacheKey($feedId), $batchId, self::CACHE_TTL);
+        } catch (Throwable $e) {
+            Craft::error('Audit: failed to open Feed Me batch — ' . $e->getMessage(), __METHOD__);
+        }
+    }
+
+    /**
+     * Close the batch when Feed Me finishes processing a feed.
+     *
+     * If no cached batch ID is found, the BEFORE event never fired (or the
+     * cache was cleared) — silently no-op.
+     */
+    public function onAfterProcessFeed(Event $event): void
+    {
+        try {
+            $feed = $event->feed ?? null;
+            if ($feed === null || !isset($feed->id)) {
+                return;
+            }
+            $feedId = (int) $feed->id;
+            $cacheKey = $this->cacheKey($feedId);
+            $batchId = Craft::$app->getCache()->get($cacheKey);
+            if (!$batchId) {
+                Craft::info(
+                    "Audit: onAfterProcessFeed for feed {$feedId} found no cached batch — skipping close",
+                    __METHOD__
+                );
+                return;
+            }
+            Audit::$plugin->batch->close((int) $batchId);
+            Craft::$app->getCache()->delete($cacheKey);
+        } catch (Throwable $e) {
+            Craft::error('Audit: failed to close Feed Me batch — ' . $e->getMessage(), __METHOD__);
+        }
+    }
+
+    protected function cacheKey(int $feedId): string
+    {
+        return 'audit:feedme:' . $feedId;
+    }
+}

--- a/tests/Feature/FeedMeListenerTest.php
+++ b/tests/Feature/FeedMeListenerTest.php
@@ -1,0 +1,205 @@
+<?php
+
+use superbig\audit\Audit;
+use superbig\audit\enums\AuditEvent;
+use superbig\audit\records\AuditRecord;
+use superbig\audit\services\FeedMeListener;
+use yii\base\Event;
+
+/**
+ * Stub for Feed Me's FeedProcessEvent — yii\base\Event uses BaseObject which
+ * rejects unknown property assignment, so we declare $feed explicitly. The
+ * listener accepts any yii\base\Event subclass and reads $event->feed
+ * defensively.
+ */
+class FeedProcessEventStub extends Event
+{
+    public ?object $feed = null;
+    public array $feedData = [];
+}
+
+beforeEach(function () {
+    AuditRecord::deleteAll();
+
+    // PHPUnit 10+ converts E_WARNING into test warnings even when the source
+    // suppresses with the @-operator. Yii's FileCache::getValue() calls
+    // @filemtime() against cache files that may have been removed by GC, and
+    // those produce stat-failed warnings that surface as test warnings even
+    // though FileCache treats them as cache misses (which is the correct
+    // behavior). Filter just those out — anything else still propagates.
+    set_error_handler(function (int $errno, string $errstr, string $errfile): bool {
+        if (
+            $errno === E_WARNING
+            && str_contains($errstr, 'filemtime')
+            && str_contains($errfile, 'FileCache.php')
+        ) {
+            return true; // suppress
+        }
+        return false; // let PHPUnit handle anything else
+    }, E_WARNING);
+});
+
+afterEach(function () {
+    restore_error_handler();
+});
+
+/**
+ * Build a synthetic event whose $feed property mimics Feed Me's FeedModel.
+ *
+ * Feed Me's FeedProcessEvent extends yii\base\Event and adds public $feed
+ * (a FeedModel instance). Our listener only reads $event->feed defensively
+ * via $event->feed ?? null, so any object with the right shape works.
+ */
+function makeFeedEvent(?int $feedId, string $name = 'Test Feed', string $elementType = 'craft\elements\Entry'): Event
+{
+    $feed = new \stdClass();
+    if ($feedId !== null) {
+        $feed->id = $feedId;
+    }
+    $feed->name = $name;
+    $feed->elementType = $elementType;
+    $feed->siteId = 1;
+
+    $event = new FeedProcessEventStub();
+    $event->feed = $feed;
+    return $event;
+}
+
+it('feedMeAvailable() returns false when Feed Me is not installed', function () {
+    $listener = new FeedMeListener();
+    expect($listener->feedMeAvailable())->toBeFalse();
+});
+
+it('init() registers nothing harmful when Feed Me is not installed', function () {
+    $listener = new FeedMeListener();
+    $listener->init();
+    expect($listener->feedMeAvailable())->toBeFalse();
+});
+
+it('opens a batch when onBeforeProcessFeed is called', function () {
+    $listener = Audit::$plugin->feedMeListener;
+    $event = makeFeedEvent(feedId: 42, name: 'Products');
+
+    expect(Audit::$plugin->batch->currentBatchId())->toBeNull();
+    $listener->onBeforeProcessFeed($event);
+    expect(Audit::$plugin->batch->currentBatchId())->not->toBeNull();
+
+    $batchId = Audit::$plugin->batch->currentBatchId();
+    $parent = AuditRecord::findOne($batchId);
+    expect($parent)->not->toBeNull();
+    expect($parent->title)->toBe('Feed Me: Products');
+    expect($parent->event)->toBe(AuditEvent::BatchStarted->value);
+
+    $snapshot = json_decode($parent->snapshot, true);
+    expect($snapshot['metadata']['source'])->toBe('feed-me');
+    expect($snapshot['metadata']['feedId'])->toBe(42);
+    expect($snapshot['metadata']['elementType'])->toBe('craft\elements\Entry');
+
+    // Clean up.
+    Audit::$plugin->batch->close($batchId);
+});
+
+it('writes the batch ID to the cache under audit:feedme:<feedId>', function () {
+    $listener = Audit::$plugin->feedMeListener;
+    $event = makeFeedEvent(feedId: 99);
+    $listener->onBeforeProcessFeed($event);
+
+    $cached = Craft::$app->getCache()->get('audit:feedme:99');
+    expect($cached)->not->toBeFalse();
+    expect((int) $cached)->toBe(Audit::$plugin->batch->currentBatchId());
+
+    Audit::$plugin->batch->close((int) $cached);
+});
+
+it('closes the batch when onAfterProcessFeed is called', function () {
+    $listener = Audit::$plugin->feedMeListener;
+    $event = makeFeedEvent(feedId: 7);
+
+    $listener->onBeforeProcessFeed($event);
+    $batchId = Audit::$plugin->batch->currentBatchId();
+    expect($batchId)->not->toBeNull();
+
+    $listener->onAfterProcessFeed($event);
+
+    expect(Audit::$plugin->batch->currentBatchId())->toBeNull();
+    expect(Craft::$app->getCache()->get('audit:feedme:7'))->toBeFalse();
+
+    $parent = AuditRecord::findOne($batchId);
+    expect($parent->event)->toBe(AuditEvent::BatchCompleted->value);
+});
+
+it('audit rows written between Before and After inherit the batch parentId', function () {
+    $listener = Audit::$plugin->feedMeListener;
+    $event = makeFeedEvent(feedId: 11);
+
+    $listener->onBeforeProcessFeed($event);
+    $batchId = Audit::$plugin->batch->currentBatchId();
+
+    $child = Audit::$plugin->auditRecorder->record(
+        event: AuditEvent::EntrySaved,
+        title: 'Imported entry',
+    );
+
+    $listener->onAfterProcessFeed($event);
+
+    expect((int) $child->parentId)->toBe($batchId);
+});
+
+it('onAfterProcessFeed without a paired Before is a silent no-op', function () {
+    $listener = Audit::$plugin->feedMeListener;
+    $event = makeFeedEvent(feedId: 404);
+
+    // No Before — directly call After. Should not throw, no batch closed.
+    $listener->onAfterProcessFeed($event);
+
+    expect(Audit::$plugin->batch->currentBatchId())->toBeNull();
+    expect((int) AuditRecord::find()->count())->toBe(0);
+});
+
+it('onBeforeProcessFeed handles a missing feed.id gracefully', function () {
+    $listener = Audit::$plugin->feedMeListener;
+    $event = makeFeedEvent(feedId: null);  // no id property
+
+    $listener->onBeforeProcessFeed($event);
+
+    expect(Audit::$plugin->batch->currentBatchId())->toBeNull();
+    expect((int) AuditRecord::find()->count())->toBe(0);
+});
+
+it('onBeforeProcessFeed handles a missing feed property gracefully', function () {
+    $listener = Audit::$plugin->feedMeListener;
+    $event = new FeedProcessEventStub();  // $feed is null
+
+    $listener->onBeforeProcessFeed($event);
+
+    expect(Audit::$plugin->batch->currentBatchId())->toBeNull();
+    expect((int) AuditRecord::find()->count())->toBe(0);
+});
+
+it('survives a feed close mid-batch via the cache (pagination case)', function () {
+    $listener = Audit::$plugin->feedMeListener;
+    $event = makeFeedEvent(feedId: 55);
+
+    $listener->onBeforeProcessFeed($event);
+    $batchId = Audit::$plugin->batch->currentBatchId();
+
+    // Write a child while the batch is open.
+    Audit::$plugin->auditRecorder->record(
+        event: AuditEvent::EntrySaved,
+        title: 'Imported during pagination page 1',
+    );
+
+    // Cache should carry the batch ID, ready for a separate-process After.
+    $cachedBatchId = Craft::$app->getCache()->get('audit:feedme:55');
+    expect((int) $cachedBatchId)->toBe($batchId);
+
+    $listener->onAfterProcessFeed($event);
+
+    expect(Craft::$app->getCache()->get('audit:feedme:55'))->toBeFalse();
+
+    $parent = AuditRecord::findOne($batchId);
+    expect($parent->event)->toBe(AuditEvent::BatchCompleted->value);
+
+    $snapshot = json_decode($parent->snapshot, true);
+    expect($snapshot['childCount'])->toBe(1);
+});


### PR DESCRIPTION
## P3.4: Feed Me bake-in — automatic batch-per-feed-import

Adds first-party Feed Me integration without making Feed Me a hard dependency. When Feed Me is installed, each feed import is automatically wrapped in an audit batch: all element saves, permission changes, and other audit events that happen during the import are grouped under a single `BatchStarted`/`BatchCompleted` parent row.

Detection is deferred: `FeedMeListener` registers itself on `Plugins::EVENT_AFTER_LOAD_PLUGINS` and probes `class_exists('craft\feedme\services\Process')` before attaching any handlers. If Feed Me isn't installed, the listener is a no-op. String-literal FQCNs are stored in private constants so PHPStan stays happy when Feed Me isn't in the project.

Paginated feeds (where Feed Me re-queues the job for each page) are handled via Craft's cache: the batch ID is stored under `audit:feedme:<feedId>` with a 24-hour TTL so the same batch stays open across multiple queue jobs for the same feed run.

### What changed

- **`src/services/FeedMeListener.php`** (new, 170 LOC) — listens to `EVENT_BEFORE_PROCESS_FEED` (opens batch, caches ID) and `EVENT_AFTER_PROCESS_FEED` (closes batch, clears cache). Deferred registration via `Plugins::EVENT_AFTER_LOAD_PLUGINS`. Eager init in `Audit.php` via `$this->get('feedMeListener')`.
- **`src/Audit.php`** (+9 LOC) — registers `FeedMeListener` in the service container and eagerly initializes it so the deferred plugin-load listener fires.
- **`tests/Feature/FeedMeListenerTest.php`** (new, 205 LOC, +10 tests) — covers batch open/close lifecycle, cross-process cache survival, missing-feed-id edge case, idempotent close, and the class_exists guard.

### Tests

- +10 tests
- ECS clean
- PHPStan clean
- Fresh-DB green

### Stacked on

`p3.2-resave-elements-to-batch-service` (#117)
